### PR TITLE
fix: Prevent custom lobby setting mismatches

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -932,6 +932,22 @@ static void handleLimitSuperweaponsClick()
 #endif
 }
 
+static void WOLLockSettings()
+{
+	buttonBack->winEnable(false);
+	checkBoxLimitSuperweapons->winEnable(false);
+	comboBoxStartingCash->winEnable(false);
+
+	for (Int i = 0; i < MAX_SLOTS; ++i)
+	{
+		comboBoxPlayer[i]->winEnable(false);
+		comboBoxColor[i]->winEnable(false);
+		comboBoxPlayerTemplate[i]->winEnable(false);
+		comboBoxTeam[i]->winEnable(false);
+		buttonMapStartPosition[i]->winEnable(false);
+	}
+}
+
 static void StartPressed()
 {
 	Bool isReady = TRUE;
@@ -1107,13 +1123,6 @@ static void StartPressed()
 		std::shared_ptr<WebSocket>  pWS = NGMP_OnlineServicesManager::GetWebSocket();
 		if (pWS != nullptr)
 		{
-			// we've started, there's no going back
-						// i.e. disable the back button.
-			if (buttonBack != nullptr)
-			{
-				buttonBack->winEnable(FALSE);
-			}
-
 			if (buttonStart != nullptr)
 			{
 				buttonStart->winEnable(FALSE);
@@ -1157,6 +1166,7 @@ static void StartPressed()
 								pLobbyInterface->SendAnnouncementMessageToCurrentLobby(strInform, true);
 
 								TheNGMPGame->StartCountdown();
+								buttonSelectMap->winEnable(FALSE);		
 							}
 						}
 #endif
@@ -1880,9 +1890,6 @@ void WOLGameSetupMenuInit( WindowLayout *layout, void *userData )
 			// TODO_NGMP
 			//SendStatsToOtherPlayers(TheNGMPGame);
 
-			// we've started, there's no going back
-			// i.e. disable the back button.
-			buttonBack->winEnable(FALSE);
 			GameWindow* buttonBuddy = TheWindowManager->winGetWindowFromId(NULL, NAMEKEY("GameSpyGameOptionsMenu.wnd:ButtonCommunicator"));
 			if (buttonBuddy)
 				buttonBuddy->winEnable(FALSE);
@@ -2468,16 +2475,23 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 				// remote msg
 				UnicodeString strInform;
 				if (secondsRemaining == 1)
+				{
+					// Lock all host controlled lobby settings last second of the match start countdown
+					// to prevent late local changes not propagating to remote clients in time
+					WOLLockSettings();
+
 					strInform.format(TheGameText->fetch("LAN:GameStartTimerSingular"), secondsRemaining);
+				}
 				else
+				{
 					strInform.format(TheGameText->fetch("LAN:GameStartTimerPlural"), secondsRemaining);
+				}
 
 				NGMP_OnlineServices_LobbyInterface* pLobbyInterface = NGMP_OnlineServicesManager::GetInterface<NGMP_OnlineServices_LobbyInterface>();
 				if (pLobbyInterface != nullptr)
 				{
 					pLobbyInterface->SendAnnouncementMessageToCurrentLobby(strInform, true);
 				}
-				
 
 				// are we done?
 				if (secondsRemaining <= 0)
@@ -2679,9 +2693,6 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 
 					SendStatsToOtherPlayers(TheNGMPGame);
 
-					// we've started, there's no going back
-					// i.e. disable the back button.
-					buttonBack->winEnable(FALSE);
 					GameWindow *buttonBuddy = TheWindowManager->winGetWindowFromId(NULL, NAMEKEY("GameSpyGameOptionsMenu.wnd:ButtonCommunicator"));
 					if (buttonBuddy)
 						buttonBuddy->winEnable(FALSE);


### PR DESCRIPTION
This change locks host controlled lobby settings on the last second of the game start countdown to prevent last second local changes from not propagating to remote clients in time, which would cause desync on game start