### PR TITLE
bugfix: Clamp observer camera reset zoom level

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2281,7 +2281,8 @@ void W3DView::setHeightAboveGround(Real z)
 #if defined(GENERALS_ONLINE)
 	if (ThePlayerList && ThePlayerList->getLocalPlayer() && ThePlayerList->getLocalPlayer()->isPlayerObserver())
 	{
-		m_maxHeightAboveGround = (float)GENERALS_ONLINE_MAX_LOBBY_CAMERA_ZOOM;
+		const Real cameraHeightForReset = 500.0f;
+		m_maxHeightAboveGround = z > cameraHeightForReset ? (float)GENERALS_ONLINE_MAX_LOBBY_CAMERA_ZOOM : cameraHeightForReset;
 	}
 #endif
 


### PR DESCRIPTION
Observers were being zoomed out to the max observer height (1000) when resetting camera. 
Added a threshold so that if the current height is at or below reset level, the camera reset will be capped at a a reasonable 500 height instead of the full observer max height.