### PR TITLE
fix: Fix listbox row animation reliability to be opt-in and frame rate independent

### DIFF
--- a/Core/GameEngine/Include/GameClient/GadgetListBox.h
+++ b/Core/GameEngine/Include/GameClient/GadgetListBox.h
@@ -61,9 +61,17 @@ typedef struct _RightClickStruct
 	Int pos;
 } RightClickStruct;
 
+enum ListRowAnimMode
+{
+    LIST_ROW_ANIM_ID = 1,      // key by item ID, for lists that change order or have insertions/deletions
+    LIST_ROW_ANIM_SLOT = 2     // key by slot index, for append-only lists that don't change order
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // INLINING ///////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
+extern void SetListBoxRowAnimMode(GameWindow *window, ListRowAnimMode mode);
+extern void ApplyListBoxRowAnimation(GameWindow *window, Int rowIndex, Int rowHeight, Int &drawY);
 extern Int GadgetListBoxGetEntryBasedOnXY( GameWindow *listbox, Int x, Int y, Int &row, Int &column);
 extern void GadgetListboxCreateScrollbar( GameWindow *listbox );
 extern void GadgetListBoxAddMultiSelect( GameWindow *listbox );

--- a/Core/GameEngine/Include/GameClient/GadgetTextEntry.h
+++ b/Core/GameEngine/Include/GameClient/GadgetTextEntry.h
@@ -123,16 +123,3 @@ inline Color GadgetTextEntryGetHiliteBorderColor( GameWindow *g )					{ return g
 
 // EXTERNALS //////////////////////////////////////////////////////////////////
 
-struct GameRowAnim
-{
-	float currentIndex;
-	float targetIndex;
-	bool  alive;
-
-	GameRowAnim()
-		: currentIndex(0.0f)
-		, targetIndex(0.0f)
-		, alive(false)
-	{
-	}
-};

--- a/Core/GameEngine/Source/GameClient/GUI/Gadget/GadgetListBox.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/Gadget/GadgetListBox.cpp
@@ -2847,3 +2847,89 @@ Int GadgetListBoxGetColumnWidth( GameWindow *listbox, Int column )
 	return listboxData->columnWidth[column];
 }
 
+//=============================================================================
+// ListBox row entry animation
+// each listbox must opt in by calling SetListBoxRowAnimMode.
+//=============================================================================
+struct RowAnimState
+{
+	Real        currentIndex;   // where the row is drawn right now, catches up to targetIndex over time
+	Real        targetIndex;    // where the row actually belongs in the list
+	UnsignedInt lastUpdateTime; // last time this row was drawn
+	Bool        initialized;    // false until this row is seen for the first time
+
+	RowAnimState()
+	{
+		currentIndex = 0.f;
+		targetIndex = 0.f;
+		lastUpdateTime = 0;
+		initialized = FALSE;
+	}
+};
+
+static std::map<GameWindow*, ListRowAnimMode> theListAnimMode;
+static std::map<Int, RowAnimState> theRowAnimState;
+
+void SetListBoxRowAnimMode(GameWindow *window, ListRowAnimMode mode)
+{
+	if (!window)
+		return;
+	theListAnimMode[window] = mode;
+}
+
+void ApplyListBoxRowAnimation(GameWindow *window, Int rowIndex, Int rowHeight, Int &drawY)
+{
+	if (!window)
+		return;
+
+	// only animate listboxes that have explicitly opted in
+	std::map<GameWindow*, ListRowAnimMode>::iterator it = theListAnimMode.find(window);
+	if (it == theListAnimMode.end())
+		return;
+
+	Int animKey;
+	if (it->second == LIST_ROW_ANIM_ID)
+	{
+		Int itemID = (Int)GadgetListBoxGetItemData(window, rowIndex);
+		if (itemID <= 0)
+			return;
+
+		animKey = (window->winGetWindowId() << 16) + itemID;
+	}
+	else // LIST_ROW_ANIM_SLOT
+	{
+		animKey = (window->winGetWindowId() << 16) + rowIndex;
+	}
+
+	RowAnimState	&anim = theRowAnimState[animKey];
+	Real		   rowPos = (Real)rowIndex;
+	UnsignedInt		  now = timeGetTime();
+	Real		deltaTime = 0.f;
+
+	if (anim.lastUpdateTime != 0)
+	{
+		UnsignedInt elapsedMs = now - anim.lastUpdateTime;
+		if (elapsedMs < 100)
+			deltaTime = elapsedMs / (Real)MSEC_PER_SECOND;
+		else
+			anim.initialized = FALSE; // listbox was closed, re-animate on next open
+	}
+	anim.lastUpdateTime = now;
+
+	if (!anim.initialized)
+	{
+		// first time this row is drawn, start one row below and slides up into place
+		anim.currentIndex = rowPos + 1.f;
+		anim.targetIndex = rowPos;
+		anim.initialized = TRUE;
+	}
+	else
+	{
+		anim.targetIndex = rowPos;
+	}
+
+	const Real animSpeed = 15.f;
+	anim.currentIndex += (anim.targetIndex - anim.currentIndex) * animSpeed * deltaTime;
+
+	drawY += (Int)((anim.currentIndex - rowPos) * (Real)rowHeight);
+}

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -44,7 +44,6 @@
 #include "GameClient/GameWindowManager.h"
 #include "GameClient/GadgetComboBox.h"
 #include "GameClient/GadgetListBox.h"
-#include "GameClient/GadgetTextEntry.h"
 #include "GameClient/GameText.h"
 #include "GameClient/MapUtil.h"
 #include "GameClient/MessageBox.h"
@@ -94,38 +93,6 @@ enum {
 	COLUMN_PING,
 };
 #endif
-
-// ---------------------------------------------------------------------------
-// row entry animation
-// ---------------------------------------------------------------------------
-
-static std::map<int, GameRowAnim> g_gameListAnim;
-
-// initialize the smoothed index for this lobbyID
-static float UpdateAndGetGameRowIndex(int lobbyID, float logicalIndex)
-{
-    GameRowAnim& anim = g_gameListAnim[lobbyID];
-
-    if (!anim.alive)
-    {
-        // start slightly below, then glide into place
-        anim.currentIndex = logicalIndex + 2.f;
-        anim.targetIndex  = logicalIndex;
-        anim.alive        = true;
-    }
-    else
-    {
-        anim.targetIndex = logicalIndex;
-    }
-
-    // how fast to snap into place
-    const float t = 0.2f; 
-
-    float delta = anim.targetIndex - anim.currentIndex;
-    anim.currentIndex += delta * t;
-
-    return anim.currentIndex;
-}
 
 static NameKeyType buttonSortAlphaID = NAMEKEY_INVALID;
 static NameKeyType buttonSortPingID = NAMEKEY_INVALID;
@@ -566,6 +533,7 @@ void GrabWindowInfo()
 	listboxLobbyGamesLargeID = NAMEKEY( "WOLCustomLobby.wnd:ListboxGamesLarge" );
 	listboxLobbyGamesLarge = TheWindowManager->winGetWindowFromId(nullptr, listboxLobbyGamesLargeID);
 	listboxLobbyGamesLarge->winSetTooltipFunc(gameTooltip);
+	SetListBoxRowAnimMode(listboxLobbyGamesLarge, LIST_ROW_ANIM_ID);
 //
 //	listboxLobbyGameInfoID = NAMEKEY( "WOLCustomLobby.wnd:ListboxGameInfo" );
 //	listboxLobbyGameInfo = TheWindowManager->winGetWindowFromId(nullptr, listboxLobbyGameInfoID);
@@ -1251,13 +1219,6 @@ void RefreshGameListBox(GameWindow* win, Bool showMap)
 				for (SortedGameList::iterator sglIt = sgl.begin(); sglIt != sgl.end(); ++sglIt)
 				{
 					LobbyEntry lobby = *sglIt;
-
-                    // Logical index for this entry in the new sorted list
-					float logicalIndex = (float)i;
-
-					// register/update animation index for this lobbyID
-					UpdateAndGetGameRowIndex(lobby.lobbyID, logicalIndex);
-
 					Int index = insertGame(win, lobby, showMap);
 					if (lobby.lobbyID == selectedID)
 					{
@@ -1395,45 +1356,6 @@ void RefreshGameInfoListBox( GameWindow *mainWin, GameWindow *win )
 //	}
 
 }
-
-// ---------------------------------------------------------------------------
-// compute pixel offset for a game list row
-// ---------------------------------------------------------------------------
-int GetGameListRowPixelOffsetForRow(GameWindow* window, int rowIndex, int rowHeight)
-{
-	if (!window)
-		return 0;
-
-	// We rely on listbox item data storing lobbyID, like RefreshGameListBox uses
-	Int lobbyID = (Int)GadgetListBoxGetItemData(window, rowIndex);
-	if (lobbyID == 0)
-		return 0;
-
-    GameWindow* mainGameList = GetGameListBox();
-
-    int animKey;
-    if (window == mainGameList)
-    {
-        // For the main game list: use lobbyID
-        animKey = lobbyID;
-    }
-    else
-    {
-        // For all other lists: keep per row key to avoid overlap
-        animKey = lobbyID * 1024 + rowIndex;
-    }
-
-
-	// Get smoothed "visual index" for this lobbyID
-	float visualIndex = UpdateAndGetGameRowIndex(animKey, (float)rowIndex);
-
-	// Offset = (visualIndex - logicalIndex) * rowHeight
-	float offsetRows = visualIndex - (float)rowIndex;
-	int pixelOffset = (int)(offsetRows * (float)rowHeight);
-
-	return pixelOffset;
-}
-
 
 void RefreshGameListBoxes( void )
 {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp
@@ -56,8 +56,6 @@
 
 // DEFINES ////////////////////////////////////////////////////////////////////
 
-int GetGameListRowPixelOffsetForRow(GameWindow* window, int rowIndex, int rowHeight);
-
 // PRIVATE TYPES //////////////////////////////////////////////////////////////
 
 // PRIVATE DATA ///////////////////////////////////////////////////////////////
@@ -197,13 +195,8 @@ static void drawListBoxText( GameWindow *window, WinInstanceData *instData,
 	IRegion2D clipRegion;
 	ICoord2D start, end;
 
-    Color debugBg = TheWindowManager->winMakeColor(3, 93, 166, 20);
-	TheWindowManager->winFillRect(
-		debugBg,
-		WIN_DRAW_LINE_WIDTH,
-		x, y,
-		x + width, y + height
-	);
+    Color WindowBg = TheWindowManager->winMakeColor(3, 93, 166, 20);
+	TheWindowManager->winFillRect(WindowBg, WIN_DRAW_LINE_WIDTH, x, y, x + width, y + height);
 
 	//
 	// save the clipping information region cause we're going to use it here
@@ -244,8 +237,7 @@ static void drawListBoxText( GameWindow *window, WinInstanceData *instData,
 		selected = FALSE;
 
 		int rowDrawY = drawY;
-
-		rowDrawY += GetGameListRowPixelOffsetForRow(window, i, listLineHeight);
+		ApplyListBoxRowAnimation(window, i, listLineHeight, rowDrawY);
 
 		if (list->multiSelect)
 		{
@@ -682,4 +674,3 @@ void W3DGadgetListBoxImageDraw( GameWindow *window, WinInstanceData *instData )
 
 
 }
-

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -189,6 +189,8 @@ void InitBuddyControls(Int type)
 		buddyControls.listboxChatID = TheNameKeyGenerator->nameToKey( "WOLBuddyOverlay.wnd:ListboxBuddyChat" );
 		buddyControls.listboxBuddies = TheWindowManager->winGetWindowFromId( nullptr,  buddyControls.listboxBuddiesID );
 		buddyControls.listboxChat = TheWindowManager->winGetWindowFromId( nullptr,  buddyControls.listboxChatID);
+		SetListBoxRowAnimMode(buddyControls.listboxChat, LIST_ROW_ANIM_SLOT);
+		SetListBoxRowAnimMode(buddyControls.listboxBuddies, LIST_ROW_ANIM_ID);
 		GadgetTextEntrySetText(buddyControls.textEntryEdit, UnicodeString::TheEmptyString);
 		buddyControls.isInit = TRUE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1504,6 +1504,7 @@ void InitWOLGameGadgets()
 	textEntryChat = TheWindowManager->winGetWindowFromId( parentWOLGameSetup, textEntryChatID );
 	textEntryMapDisplay = TheWindowManager->winGetWindowFromId( parentWOLGameSetup, textEntryMapDisplayID );
 	windowMap = TheWindowManager->winGetWindowFromId( parentWOLGameSetup,windowMapID  );
+	SetListBoxRowAnimMode(listboxGameSetupChat, LIST_ROW_ANIM_SLOT);
   DEBUG_ASSERTCRASH(windowMap, ("Could not find the parentWOLGameSetup.wnd:MapWindow" ));
 
   checkBoxLimitSuperweapons = TheWindowManager->winGetWindowFromId( parentWOLGameSetup, checkBoxLimitSuperweaponsID );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -1268,9 +1268,11 @@ void WOLLobbyMenuInit( WindowLayout *layout, void *userData )
 	listboxLobbyPlayersID = TheNameKeyGenerator->nameToKey("WOLCustomLobby.wnd:ListboxPlayers");
 	listboxLobbyPlayers = TheWindowManager->winGetWindowFromId(parent, listboxLobbyPlayersID);
 	listboxLobbyPlayers->winSetTooltipFunc(playerTooltip);
+	SetListBoxRowAnimMode(listboxLobbyPlayers, LIST_ROW_ANIM_ID);
 
 	listboxLobbyChatID = TheNameKeyGenerator->nameToKey("WOLCustomLobby.wnd:ListboxChat");
 	listboxLobbyChat = TheWindowManager->winGetWindowFromId(parent, listboxLobbyChatID);
+	SetListBoxRowAnimMode(listboxLobbyChat, LIST_ROW_ANIM_SLOT);
 
 	comboLobbyGroupRoomsID = TheNameKeyGenerator->nameToKey("WOLCustomLobby.wnd:ComboBoxGroupRooms");
 	comboLobbyGroupRooms = TheWindowManager->winGetWindowFromId(parent, comboLobbyGroupRoomsID);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -945,6 +945,8 @@ void WOLQuickMatchMenuInit( WindowLayout *layout, void *userData )
 		mapListboxPreviewFunc = listboxMapSelect->winGetDrawFunc();
 		listboxMapSelect->winSetDrawFunc(updateMapHoverPreview);
 	}
+	SetListBoxRowAnimMode(quickmatchTextWindow, LIST_ROW_ANIM_SLOT);
+	SetListBoxRowAnimMode(listboxMapSelect, LIST_ROW_ANIM_SLOT);
 	//textEntryMaxDisconnects = TheWindowManager->winGetWindowFromId( parentWOLQuickMatch, textEntryMaxDisconnectsID );
 	//textEntryMaxPoints = TheWindowManager->winGetWindowFromId( parentWOLQuickMatch, textEntryMaxPointsID );
 	//textEntryMinPoints = TheWindowManager->winGetWindowFromId( parentWOLQuickMatch, textEntryMinPointsID );


### PR DESCRIPTION
This PR is a proper reimplementation for listbox entry animations we introduced in #239 
The original implementation lived in `LobbyUtils.cpp` and only worked for specific and sometimes unintended listboxes. This refactor moves all animation logic we introduced into `GadgetListBox.cpp` where it is available to any listbox in the game, and makes it opt-in via `SetListBoxRowAnimMode` so only intended listboxes would animate their entry rows.

fixes:
- Animation is now frame rate independent.
- Listboxes that were not intended to animate no longer do so since only listboxes that we opt in would animate now.
- Fixes the issue where rows stopped animating after reopening a listbox because stale animation state from previous sessions was being reused.

Other listboxes can be opted in by calling SetListBoxRowAnimMode at init time