### PR TITLE
fix: Fix lobby lockup when hosting while disconnected from backend

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupHostGame.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupHostGame.cpp
@@ -676,6 +676,9 @@ void createGame()
 	NGMP_OnlineServices_LobbyInterface* pLobbyInterface = NGMP_OnlineServicesManager::GetInterface<NGMP_OnlineServices_LobbyInterface>();
 	if (!pLobbyInterface)
 	{
+		parentPopup = nullptr;
+		GameSpyCloseOverlay(GSOVERLAY_GAMEOPTIONS);
+		SetLobbyAttemptHostJoin(FALSE);
 		GSMessageBoxOk(UnicodeString(L"Error"), UnicodeString(L"Failed to get Online Services Lobby Interface!"));
 		return;
 	}


### PR DESCRIPTION
Fixes a bug where attempting to host a game while disconnected from the service leaves the lobby UI unresponsive.

A null pLobbyInterface in createGame() returned without clearing the host attempt flag, unlike every other exit path in the file. This left s_tryingToHostOrJoin TRUE which several lobby button handlers check and bail out on.