### PR TITLE
fix: Fix Frenzy smoke effect intermittently not rendering at 60Hz

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DeletionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DeletionUpdate.cpp
@@ -72,7 +72,15 @@ void DeletionUpdate::setLifetimeRange( UnsignedInt minFrames, UnsignedInt maxFra
 UnsignedInt DeletionUpdate::calcSleepDelay(UnsignedInt minFrames, UnsignedInt maxFrames)
 {
 	UnsignedInt delay = GameLogicRandomValue( minFrames, maxFrames );
+#if defined(GENERALS_ONLINE_HIGH_FPS_SERVER)
+	// Info: At 60Hz, a 1 logic frame lifetime only gives the client 16ms real time to notice a newly created object and
+	// render it before DeletionUpdate destroys it, versus 33ms at the retail 30hz.
+	// This caused one frame objects (like Frenzy's cloud effect) to intermittently never get drawn. 
+	// Doubling the 1 frame case just restores the original real world time.
+	if (delay <= 1) delay = 2;
+#else
 	if (delay < 1) delay = 1;
+#endif
 	m_dieFrame = TheGameLogic->getFrame() + delay;
 	return delay;
 }


### PR DESCRIPTION
Fixes a bug where the Frenzy ground smoke effect would intermittently fail to render at 60hz.

The object that hosts the Frenzy cloud particle system is destroyed by `DeletionUpdate` after 1 logic frame. 
At 30Hz, 1 logic frame gives the client 33ms to notice the newly created object and render it before it's destroyed. 
At 60Hz, that same 1 frame lifetime only gives ~16ms, which isn't always enough real world time for the client to catch up, hence why the smoke would randomly not work.

On the left - before
On the right - after


https://github.com/user-attachments/assets/3c92c26d-42e6-453d-8342-429605c695f4

