### PR TITLE
genovly audio-v2: startup-chain tracing + overlay upgrade-queue debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ cmake-build-*/
 .ninja_log
 build.ninja
 
+## Overlay project documentation (NOT for public repo)
+/overlay-project-status.md
+
 ## Python
 __pycache__/
 *.pyc

--- a/Core/GameEngine/Source/Common/System/SubsystemInterface.cpp
+++ b/Core/GameEngine/Source/Common/System/SubsystemInterface.cpp
@@ -29,6 +29,29 @@
 #include "Common/SubsystemInterface.h"
 #include "Common/Xfer.h"
 
+#include <cstdarg>	// TheSuperHackers @debug 18/07/2026 va_list for traceLog
+#include <cstdio>	// TheSuperHackers @debug 18/07/2026 fopen/vfprintf for traceLog
+
+// TheSuperHackers @debug 18/07/2026 Startup-chain tracing — audio investigation.
+static FILE* g_traceLogFile_subsys = nullptr;
+static void traceLog(const char* fmt, ...)
+{
+	__try {
+		if (!g_traceLogFile_subsys) {
+			g_traceLogFile_subsys = fopen("genovly_debug.log", "a");
+		}
+		if (g_traceLogFile_subsys) {
+			va_list args;
+			va_start(args, fmt);
+			vfprintf(g_traceLogFile_subsys, fmt, args);
+			va_end(args);
+			fflush(g_traceLogFile_subsys);
+		}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+	}
+}
+
 
 #ifdef DUMP_PERF_STATS
 #include "GameLogic/GameLogic.h"
@@ -156,7 +179,9 @@ void SubsystemInterfaceList::removeSubsystem(SubsystemInterface* sys)
 void SubsystemInterfaceList::initSubsystem(SubsystemInterface* sys, const char* path1, const char* path2, Xfer* pXfer, AsciiString name)
 {
     sys->setName(name);
+	traceLog("TRACE: subsys init '%s'...\n", name.str());
     sys->init();
+	traceLog("TRACE: subsys '%s' init done\n", name.str());
 
     INI ini;
     if (path1)

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -66,6 +66,31 @@
 
 #include "Common/file.h"
 
+#include <cstdarg>	// TheSuperHackers @debug 18/07/2026 va_list for audioLog
+#include <cstdio>	// TheSuperHackers @debug 18/07/2026 fopen/vfprintf for audioLog
+
+// TheSuperHackers @debug 18/07/2026 Audio init tracing — writes to genovly_debug.log.
+// Investigation: our exe produces no audio even with the original mss32.dll.
+static FILE* g_audioLogFile = nullptr;
+static void audioLog(const char* fmt, ...)
+{
+	__try {
+		if (!g_audioLogFile) {
+			g_audioLogFile = fopen("genovly_debug.log", "a");
+		}
+		if (g_audioLogFile) {
+			va_list args;
+			va_start(args, fmt);
+			vfprintf(g_audioLogFile, fmt, args);
+			va_end(args);
+			fflush(g_audioLogFile);
+		}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		// Logging itself failed -- silently ignore, never crash the game
+	}
+}
+
 
 enum { INFINITE_LOOP_COUNT = 1000000 };
 
@@ -437,6 +462,7 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::init()
 {
+	audioLog("AUDIO: MilesAudioManager::init() entry -- REAL manager (not dummy)\n");
 	AudioManager::init();
 #ifdef INTENSE_DEBUG
 	DEBUG_LOG(("Sound has temporarily been disabled in debug builds only. jkmcd"));
@@ -1450,8 +1476,10 @@ AsciiString MilesAudioManager::getMusicTrackName() const
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::openDevice()
 {
+	audioLog("AUDIO: openDevice entry m_audioOn=%d\n", TheGlobalData ? (Int)TheGlobalData->m_audioOn : -1);
 	if (!TheGlobalData->m_audioOn) {
 		m_digitalHandle = nullptr;
+		audioLog("AUDIO: early-return reason=audio_off\n");
 		return;
 	}
 
@@ -1460,15 +1488,21 @@ void MilesAudioManager::openDevice()
 
 	AIL_set_redist_directory("MSS\\");
 	AIL_startup();
+	audioLog("AUDIO: AIL_startup done\n");
 	Int retval = 0;
 
 	// AIL_quick_startup should be replaced later with a call to actually pick which device to use, etc
 	const AudioSettings *audioSettings = getAudioSettings();
 	m_selectedSpeakerType = TheAudio->translateSpeakerTypeToUnsignedInt(m_prefSpeaker);
+	audioLog("AUDIO: quick_startup args digital=%d midi=%d rate=%d bits=%d ch=%d speakerType=%u\n",
+		(Int)audioSettings->m_useDigital, (Int)audioSettings->m_useMidi, (Int)audioSettings->m_outputRate,
+		(Int)audioSettings->m_outputBits, (Int)audioSettings->m_outputChannels, m_selectedSpeakerType);
 
 	retval = AIL_quick_startup(audioSettings->m_useDigital, audioSettings->m_useMidi, audioSettings->m_outputRate, audioSettings->m_outputBits, audioSettings->m_outputChannels);
+	audioLog("AUDIO: quick_startup retval=%d\n", retval);
 
 	if (!retval) {
+		audioLog("AUDIO: early-return reason=quick_startup_failed\n");
 		// Initialization failed - ensure m_digitalHandle stays nullptr and audio is disabled
 		m_digitalHandle = nullptr;
 		setOn(false, AudioAffect_All);
@@ -1477,26 +1511,33 @@ void MilesAudioManager::openDevice()
 
 	// Only get handles if initialization succeeded
 	AIL_quick_handles(&m_digitalHandle, nullptr, nullptr);
+	audioLog("AUDIO: quick_handles digitalHandle=%p\n", (void*)m_digitalHandle);
 
 	// If we still don't have a valid handle, disable audio
 	if (m_digitalHandle == nullptr) {
+		audioLog("AUDIO: early-return reason=null_handle\n");
 		setOn(false, AudioAffect_All);
 		return;
 	}
 
 	// Device initialized successfully - proceed with setup
 	buildProviderList();
+	audioLog("AUDIO: providerCount=%u pref3DProvider='%s' prefSpeaker='%s'\n",
+		m_providerCount, m_pref3DProvider.str(), m_prefSpeaker.str());
 	selectProvider(TheAudio->getProviderIndex(m_pref3DProvider));
+	audioLog("AUDIO: after selectProvider selectedProvider=%u valid=%d\n", m_selectedProvider, (Int)isValidProvider());
 
 	// Now that we're all done, update the cached variables so that everything is in sync.
 	TheAudio->refreshCachedVariables();
 
 	if (!isValidProvider()) {
+		audioLog("AUDIO: early-return reason=invalid_provider\n");
 		m_digitalHandle = nullptr;  // Mark as invalid if provider check fails
 		return;
 	}
 
 	initDelayFilter();
+	audioLog("AUDIO: openDevice complete OK\n");
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/Libraries/Source/WWVegas/WWLib/mutex.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mutex.h
@@ -84,7 +84,7 @@ class CriticalSectionClass
 	// Inline storage for CRITICAL_SECTION to avoid heap allocation entirely.
 	// CRITICAL_SECTION is 40 bytes on x64 and 24 bytes on x86; 40 bytes with
 	// 8-byte alignment is sufficient for both platforms.
-	alignas(8) char handle[40];
+	__declspec(align(8)) char handle[40];
 	unsigned locked;
 
 	// Lock and unlock are private so that you can't use them directly. Use LockClass as a sentry instead!

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -627,6 +627,7 @@ public:
   void addObserverNotificationRaw(const UnicodeString& message, Color color);
   void notifyGeneralPromotion(Player* player, ScienceType science);
   void notifySpecialPowerUsed(Player* player, const SpecialPowerTemplate* powerTemplate);
+  void onSpecialPowerTriggered(Player* player, const SpecialPowerTemplate* spTemplate, const Coord3D& location);
   void refreshObserverNotificationResources(void);
   Bool m_observerNotificationsHidden;   // hide/show observer notifications
 
@@ -647,6 +648,15 @@ protected:
 	virtual void crc(Xfer* xfer) override;
 	virtual void xfer(Xfer* xfer) override;
 	virtual void loadPostProcess() override;
+
+	// TheSuperHackers @feature 14/07/2026 Overlay extension data collection
+	void resolveOverlayPlayers();
+	void gatherOverlayExtData();
+	void drawUnitQueues(Int baseX, Int baseY, Int lineH, Real scale);
+	void drawPowerCooldowns(Int baseX, Int baseY, Int lineH, Real scale);
+	void drawPowerFlashes();
+	static void collectQueueEntries(Object* obj, void* userData);
+	static void findPowerModule(Object* obj, void* userData);
 
 protected:
 
@@ -1085,6 +1095,39 @@ protected:
 	int m_currentFPS = -1;
 	int64_t lastFPSUpdate = -1;
 #endif
+
+	// TheSuperHackers @feature 14/07/2026 Spectator overlay: unit queues and power cooldowns
+	static const Int MAX_VISIBLE_QUEUE = 5;
+	static const Int MAX_POWERS_PER_PLAYER = 8;
+	enum BuildingType { BUILDING_WAR_FACTORY, BUILDING_BARRACKS, BUILDING_AIRFIELD, BUILDING_COUNT };
+
+	struct QueueEntry
+	{
+		const ThingTemplate* tmpl;
+		Real percentComplete;
+	};
+
+	struct PlayerPowerInfo
+	{
+		const CommandButton* button;
+		UnsignedInt readyFrame;
+		UnsignedInt lastUsedFrame;
+		Bool hasModule;
+	};
+
+	struct PlayerOverlayExt
+	{
+		Bool isPresent;
+		std::vector<QueueEntry> queue[BUILDING_COUNT];
+		PlayerPowerInfo powers[MAX_POWERS_PER_PLAYER];
+		Int powerCount;
+		ICoord2D powerUsePos[MAX_POWERS_PER_PLAYER];
+	};
+
+	PlayerOverlayExt m_playerOverlayExt[MAX_SLOTS];
+
+	Int m_overlayPlayerSlots[2];    // Game slot indices for the two 1v1 players
+	Bool m_isValid1v1;              // Whether we have exactly 2 active non-observer players
 
 	// ----------------------------------------------------------------------------------------------
 	// STATIC Protected Data -------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -58,6 +58,7 @@ class WindowLayout;
 class Anim2DTemplate;
 class Anim2D;
 class Shadow;
+class UpgradeTemplate;
 enum LegalBuildCode CPP_11(: Int);
 enum KindOfType CPP_11(: Int);
 enum ShadowType CPP_11(: Int);
@@ -632,6 +633,9 @@ public:
   void onUnitQueued(Player* player, const ThingTemplate* unitType, Object* producer, Real percentComplete);
   void onUnitCancelled(Player* player, const ThingTemplate* unitType, Object* producer);
   void onUnitCompleted(Player* player, const ThingTemplate* unitType, Object* producer);
+  void onUpgradeQueued(Player* player, const UpgradeTemplate* upgradeType, Object* producer, Real percentComplete);
+  void onUpgradeCancelled(Player* player, const UpgradeTemplate* upgradeType, Object* producer);
+  void onUpgradeCompleted(Player* player, const UpgradeTemplate* upgradeType, Object* producer);
   void onBuildingDestroyed(Object* producer);
   void refreshObserverNotificationResources(void);
   Bool m_observerNotificationsHidden;   // hide/show observer notifications
@@ -1119,11 +1123,12 @@ protected:
 
 	struct QueueEntry
 	{
-		const ThingTemplate* tmpl;
+		const ThingTemplate* tmpl;           // unit template (nullptr for upgrades)
+		const UpgradeTemplate* upgradeTmpl;  // upgrade template (nullptr for units)
 		Real percentComplete;
 		Coord3D buildingPos;       // world position of producing building (for click-to-navigate)
 		AsciiString buildingName;  // template name of producing building (for debug logging)
-		Object* producer;          // specific building instance (for accurate removal)
+		Object* producer;          // producing building instance (for removal on destroy)
 	};
 
 	struct PlayerPowerInfo

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -1145,6 +1145,7 @@ protected:
 	PlayerOverlayExt m_playerOverlayExt[MAX_SLOTS];
 
 	Int m_overlayPlayerSlots[2];    // Game slot indices for the two 1v1 players
+	Int m_queuePanelX[2];           // Runtime-snapped X positions for queue panels (frame 2)
 	Bool m_isValid1v1;              // Whether we have exactly 2 active non-observer players
 
 	// ----------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -1092,6 +1092,8 @@ protected:
     Int colWidths[numCols] = { 0 };
     Int totalWidth = 0;
     Int totalHeight = 0;
+    Int m_scoreBarLeft;      // Left edge of stats bar (cached from drawObserverStats)
+    Int m_scoreBarRight;     // Right edge of stats bar (cached from drawObserverStats)
     bool isUpdating = false;
 
 	// World Animation Data
@@ -1145,7 +1147,8 @@ protected:
 	PlayerOverlayExt m_playerOverlayExt[MAX_SLOTS];
 
 	Int m_overlayPlayerSlots[2];    // Game slot indices for the two 1v1 players
-	Int m_queuePanelX[2];           // Runtime-snapped X positions for queue panels (frame 2)
+	Int m_queuePanelX[2];           // Reference X edges: radar hi.x (P1), hud lo.x (P2) — frame 2
+	Int m_queuePanelBottomY[2];    // Reference bottom Y edges: radar/hud hi.y — frame 2
 	Bool m_isValid1v1;              // Whether we have exactly 2 active non-observer players
 
 	// ----------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -612,6 +612,7 @@ private:
 	void drawSystemTime(Int& x, Int& y);
 	void drawGameTime();
 	void drawPlayerInfoList();
+	void drawOverlayExt();  // safe overlay draw (queues + powers) — called every frame, independent of stats font
 	void drawObserverStats(Int &x, Int &y);
 	Bool m_observerStatsHidden = false;   // hide/show observer overlay
 
@@ -628,6 +629,10 @@ public:
   void notifyGeneralPromotion(Player* player, ScienceType science);
   void notifySpecialPowerUsed(Player* player, const SpecialPowerTemplate* powerTemplate);
   void onSpecialPowerTriggered(Player* player, const SpecialPowerTemplate* spTemplate, const Coord3D& location);
+  void onUnitQueued(Player* player, const ThingTemplate* unitType, Object* producer, Real percentComplete);
+  void onUnitCancelled(Player* player, const ThingTemplate* unitType, Object* producer);
+  void onUnitCompleted(Player* player, const ThingTemplate* unitType, Object* producer);
+  void onBuildingDestroyed(Object* producer);
   void refreshObserverNotificationResources(void);
   Bool m_observerNotificationsHidden;   // hide/show observer notifications
 
@@ -649,14 +654,23 @@ protected:
 	virtual void xfer(Xfer* xfer) override;
 	virtual void loadPostProcess() override;
 
+public: // TheSuperHackers: overlay methods must be public for file-scope safe* wrappers
 	// TheSuperHackers @feature 14/07/2026 Overlay extension data collection
 	void resolveOverlayPlayers();
 	void gatherOverlayExtData();
 	void drawUnitQueues(Int baseX, Int baseY, Int lineH, Real scale);
 	void drawPowerCooldowns(Int baseX, Int baseY, Int lineH, Real scale);
 	void drawPowerFlashes();
+	void drawUnitQueueClicks();  // click-to-navigate for queue icons
 	static void collectQueueEntries(Object* obj, void* userData);
 	static void findPowerModule(Object* obj, void* userData);
+
+	// TheSuperHackers @feature 15/07/2026 SEH-safe Impl methods (called via safe* wrappers)
+	void gatherOverlayExtDataImpl();
+	void drawUnitQueuesImpl(Int baseX, Int baseY, Int lineH, Real scale);
+	void drawPowerCooldownsImpl(Int baseX, Int baseY, Int lineH, Real scale);
+	void drawPowerFlashesImpl();
+	void drawUnitQueueClicksImpl();  // click-to-navigate for queue icons
 
 protected:
 
@@ -1105,6 +1119,9 @@ protected:
 	{
 		const ThingTemplate* tmpl;
 		Real percentComplete;
+		Coord3D buildingPos;       // world position of producing building (for click-to-navigate)
+		AsciiString buildingName;  // template name of producing building (for debug logging)
+		Object* producer;          // specific building instance (for accurate removal)
 	};
 
 	struct PlayerPowerInfo
@@ -1119,7 +1136,7 @@ protected:
 	struct PlayerOverlayExt
 	{
 		Bool isPresent;
-		std::vector<QueueEntry> queue[BUILDING_COUNT];
+		std::vector<QueueEntry> queue;  // flat queue across all building types, sorted by spawn order
 		PlayerPowerInfo powers[MAX_POWERS_PER_PLAYER];
 		Int powerCount;
 		ICoord2D powerUsePos[MAX_POWERS_PER_PLAYER];

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -1112,6 +1112,7 @@ protected:
 		const CommandButton* button;
 		UnsignedInt readyFrame;
 		UnsignedInt lastUsedFrame;
+		UnsignedInt cooldownEndFrame;  // Our own cooldown tracker (set by onSpecialPowerTriggered)
 		Bool hasModule;
 	};
 

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/Vendor/ValveNetworkingSockets/steam/steamtypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/Vendor/ValveNetworkingSockets/steam/steamtypes.h
@@ -59,8 +59,14 @@ typedef unsigned __int32 uintp;
 
 typedef short int16;
 typedef unsigned short uint16;
-typedef int int32;
-typedef unsigned int uint32;
+
+// Match bittype.h from Westwood Library (included via PCH) which defines:
+//   typedef unsigned long  uint32;
+//   typedef signed long    sint32;
+// Using long instead of int/int32 avoids C++ duplicate typedef errors on MinGW.
+typedef unsigned long uint32;
+typedef signed long int32;
+
 typedef long long int64;
 typedef unsigned long long uint64;
 

--- a/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -80,7 +80,6 @@ class STLSpecialAlloc;
 #include <time.h>
 #include <vfw.h>
 #include <winerror.h>
-#include <wininet.h>
 #include <winreg.h>
 
 #ifndef DIRECTINPUT_VERSION

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -28,6 +28,29 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
+#include <cstdarg>	// TheSuperHackers @debug 18/07/2026 va_list for traceLog
+#include <cstdio>	// TheSuperHackers @debug 18/07/2026 fopen/vfprintf for traceLog
+
+// TheSuperHackers @debug 18/07/2026 Startup-chain tracing — audio investigation.
+static FILE* g_traceLogFile_gameengine = nullptr;
+static void traceLog(const char* fmt, ...)
+{
+	__try {
+		if (!g_traceLogFile_gameengine) {
+			g_traceLogFile_gameengine = fopen("genovly_debug.log", "a");
+		}
+		if (g_traceLogFile_gameengine) {
+			va_list args;
+			va_start(args, fmt);
+			vfprintf(g_traceLogFile_gameengine, fmt, args);
+			va_end(args);
+			fflush(g_traceLogFile_gameengine);
+		}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+	}
+}
+
 #include "Common/ActionManager.h"
 #include "Common/AudioAffect.h"
 #include "Common/BuildAssistant.h"
@@ -392,6 +415,7 @@ Bool GameEngine::isGameHalted()
  */
 void GameEngine::init()
 {
+	traceLog("TRACE: GameEngine::init() entry\n");
 	try {
 		//create an INI object to use for loading stuff
 		INI ini;
@@ -575,7 +599,9 @@ void GameEngine::init()
   startTime64 = endTime64;//Reset the clock ////////////////////////////////////////////////////////
 	DEBUG_LOG(("%s", Buf));////////////////////////////////////////////////////////////////////////////
 	#endif/////////////////////////////////////////////////////////////////////////////////////////////
+		traceLog("TRACE: before TheAudio initSubsystem headless=%d\n", TheGlobalData ? (Int)TheGlobalData->m_headless : -1);
 		initSubsystem(TheAudio,"TheAudio", createAudioManager(TheGlobalData->m_headless), nullptr);
+		traceLog("TRACE: after TheAudio initSubsystem TheAudio=%p\n", (void*)TheAudio);
 
 #if RTS_ZEROHOUR && RETAIL_COMPATIBLE_CRC
 		TheNameKeyGenerator->syncNameKeyID();

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
@@ -32,6 +32,29 @@
 #include "Common/GameEngine.h"
 #include "Common/ReplaySimulation.h"
 
+#include <cstdarg>	// TheSuperHackers @debug 18/07/2026 va_list for traceLog
+#include <cstdio>	// TheSuperHackers @debug 18/07/2026 fopen/vfprintf for traceLog
+
+// TheSuperHackers @debug 18/07/2026 Startup-chain tracing — audio investigation.
+static FILE* g_traceLogFile_gamemain = nullptr;
+static void traceLog(const char* fmt, ...)
+{
+	__try {
+		if (!g_traceLogFile_gamemain) {
+			g_traceLogFile_gamemain = fopen("genovly_debug.log", "a");
+		}
+		if (g_traceLogFile_gamemain) {
+			va_list args;
+			va_start(args, fmt);
+			vfprintf(g_traceLogFile_gamemain, fmt, args);
+			va_end(args);
+			fflush(g_traceLogFile_gamemain);
+		}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+	}
+}
+
 
 /**
  * This is the entry point for the game system.
@@ -40,10 +63,14 @@ Int GameMain()
 {
 	int exitcode = 0;
 	// initialize the game engine using factory function
+	traceLog("TRACE: GameMain entry\n");
 	TheFramePacer = new FramePacer();
 	TheFramePacer->enableFramesPerSecondLimit(TRUE);
 	TheGameEngine = CreateGameEngine();
+	traceLog("TRACE: engine created TheGameEngine=%p\n", (void*)TheGameEngine);
+	traceLog("TRACE: calling TheGameEngine->init()\n");
 	TheGameEngine->init();
+	traceLog("TRACE: TheGameEngine->init() returned\n");
 
 	if (TheGlobalData->m_exportStats && (!TheGlobalData->m_headless || TheGlobalData->m_simulateReplays.empty()))
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupJoinGame.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupJoinGame.cpp
@@ -62,8 +62,8 @@
 #include "GameNetwork/GameSpy/PeerDefs.h"
 #include "GameNetwork/GameSpy/PeerThread.h"
 #include "GameNetwork/GameSpyOverlay.h"
-#include "../ngmp_include.h"
-#include "../ngmp_interfaces.h"
+#include "GameNetwork/GeneralsOnline/NGMP_include.h"
+#include "GameNetwork/GeneralsOnline/NGMP_interfaces.h"
 
 
 //-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupPlayerInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupPlayerInfo.cpp
@@ -60,8 +60,8 @@
 
 #include "WWDownload/Registry.h"
 
-#include "../ngmp_interfaces.h"
-#include "../ngmp_include.h"
+#include "GameNetwork/GeneralsOnline/NGMP_interfaces.h"
+#include "GameNetwork/GeneralsOnline/NGMP_include.h"
 #include "../OnlineServices_Init.h"
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -368,7 +368,8 @@ void HandleOverallStats( const char* szHTTPStats, unsigned len )
 		//      we want win% = team's wins / total # games played by all teams
 		const char* pTotal = FindNextNumber(pSide);
 		const char* pWins = FindNextNumber(pTotal);
-		float percent = atof(pWins) / max(1,atof(pTotal));  //max prevents divide by zero
+		float total = atof(pTotal);
+		float percent = atof(pWins) / (total < 1 ? 1 : total);  //max prevents divide by zero
 		s_totalWinPercent += percent;
 
 		s_winStats.insert(std::make_pair( side, percent ));

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1410,6 +1410,10 @@ InGameUI::InGameUI()
 		m_overlayPlayerSlots[1] = -1;
 		m_queuePanelX[0] = 0;
 		m_queuePanelX[1] = 0;
+		m_queuePanelBottomY[0] = 0;
+		m_queuePanelBottomY[1] = 0;
+		m_scoreBarLeft = 0;
+		m_scoreBarRight = 0;
 		for (Int s = 0; s < MAX_SLOTS; ++s)
 		{
 			m_playerOverlayExt[s].isPresent = false;
@@ -6976,6 +6980,11 @@ void InGameUI::drawObserverStats(Int & x, Int & y)
 			drawY += totalRowHeight;
 		}
 	}
+
+	// Cache score bar edges for queue positioning (P1 left, P2 right)
+	m_scoreBarLeft = baseX;
+	m_scoreBarRight = baseX + bgW;
+	overlayLog("LAYOUT: scoreBar left=%d right=%d width=%d\n", m_scoreBarLeft, m_scoreBarRight, bgW);
 }
 
 void InGameUI::refreshObserverNotificationResources(void)
@@ -7958,9 +7967,17 @@ void InGameUI::drawPlayerInfoList()
 
 			overlayLog("DRAW_Q: entry valid1v1=%d\n", (Int)m_isValid1v1);
 
+			Int screenW = TheDisplay->getWidth();
 			Int screenH = TheDisplay->getHeight();
 			Int iconSize = Int(24 * scale);
 			Int iconSpacing = Int(3 * scale);
+
+			static const Int MAX_COLS = 3;
+			static const Int MAX_VISIBLE_ROWS = 3;
+			Int step = iconSize + iconSpacing;
+
+			overlayLog("LAYOUT: dims scale=%.3f iconSize=%d step=%d screenW=%d screenH=%d\n",
+				scale, iconSize, step, screenW, screenH);
 
 			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
 			{
@@ -7972,13 +7989,44 @@ void InGameUI::drawPlayerInfoList()
 				overlayLog("DRAW_Q: player slot=%d ovIdx=%d queueSize=%zu\n", slot, ovIdx, q.size());
 				if (q.empty()) continue;
 
-				// Use runtime-snapped panel X (between minimap & scoreboard, or scoreboard & right HUD)
-				Int panelX = m_queuePanelX[ovIdx];
+				// Compute panel X: position queue relative to the stats/score bar
+				// P1 goes LEFT of the score bar, P2 goes RIGHT of the score bar
+				Int panelX;
+				Int bottomY = m_queuePanelBottomY[0];
+				Int gridWidth = MAX_COLS * iconSize + (MAX_COLS - 1) * iconSpacing;
 
-				static const Int MAX_COLS = 3;
-				static const Int MAX_VISIBLE_ROWS = 3;
-				Int step = iconSize + iconSpacing;
-				Int bottomY = screenH - Int(40 * scale);  // above bottom UI
+				if (m_scoreBarLeft > 0)
+				{
+					// Stats bar is visible — position relative to it
+					if (ovIdx == 0)
+					{
+						// P1: grid left of stats bar
+						panelX = m_scoreBarLeft - gridWidth - 4;
+					}
+					else
+					{
+						// P2: grid right of stats bar
+						panelX = m_scoreBarRight + 4;
+					}
+				}
+				else
+				{
+					// Fallback: use minimap/rightHUD reference edges (frame 2 snapshot)
+					if (ovIdx == 0)
+						panelX = m_queuePanelX[0] + 4;  // right of minimap
+					else
+						panelX = m_queuePanelX[1] - gridWidth - 4;  // left of right-HUD
+				}
+
+				// Fallback if reference edges weren't captured
+				if (bottomY <= 0) bottomY = screenH;
+				if (panelX < 0) panelX = 0;
+
+				// Shift grid down by one row height (user feedback: was sitting too high)
+				bottomY += step;
+
+				overlayLog("LAYOUT: ovIdx=%d panelX=%d bottomY=%d gridRefX=%d gridRefBotY=%d\n",
+					ovIdx, panelX, bottomY, m_queuePanelX[ovIdx], m_queuePanelBottomY[ovIdx]);
 
 				// Show the OLDEST items first (row 0 at top of visible area)
 				for (size_t ei = 0; ei < q.size(); ++ei)
@@ -7990,6 +8038,9 @@ void InGameUI::drawPlayerInfoList()
 					Int ix = panelX + col * step;
 					// row 0 = top visible row, row 2 = bottom (against screen edge)
 					Int iy = bottomY - (MAX_VISIBLE_ROWS - row) * step;
+
+					overlayLog("LAYOUT: draw ovIdx=%d ei=%zu row=%d col=%d ix=%d iy=%d (botY=%d)\n",
+						ovIdx, ei, row, col, ix, iy, bottomY);
 
 					// Try drawing the button image first
 					if (q[ei].tmpl && q[ei].tmpl->getButtonImage())
@@ -8225,6 +8276,9 @@ void InGameUI::drawPlayerInfoList()
 			Int iconSize = Int(24 * scale);
 			Int iconSpacing = Int(3 * scale);
 
+			static const Int MAX_COLS = 3;
+			static const Int MAX_VISIBLE_ROWS = 3;
+
 			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
 			{
 				Int slot = m_overlayPlayerSlots[ovIdx];
@@ -8234,13 +8288,34 @@ void InGameUI::drawPlayerInfoList()
 				const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
 				if (q.empty()) continue;
 
-				// Use runtime-snapped panel X (matches drawUnitQueuesImpl)
-				Int panelX = m_queuePanelX[ovIdx];
+				// Compute panel X: position queue relative to the stats/score bar (matches drawUnitQueuesImpl)
+				// P1 goes LEFT of the score bar, P2 goes RIGHT of the score bar
+				Int panelX;
+				Int bottomY = m_queuePanelBottomY[0];
+				Int gridWidth = MAX_COLS * iconSize + (MAX_COLS - 1) * iconSpacing;
 
-				static const Int MAX_COLS = 3;
-				static const Int MAX_VISIBLE_ROWS = 3;
+				if (m_scoreBarLeft > 0)
+				{
+					if (ovIdx == 0)
+						panelX = m_scoreBarLeft - gridWidth - 4;  // P1: left of stats bar
+					else
+						panelX = m_scoreBarRight + 4;             // P2: right of stats bar
+				}
+				else
+				{
+					// Fallback: minimap/HUD refs
+					if (ovIdx == 0)
+						panelX = m_queuePanelX[0] + 4;
+					else
+						panelX = m_queuePanelX[1] - gridWidth - 4;
+				}
+				if (bottomY <= 0) bottomY = screenH;
+				if (panelX < 0) panelX = 0;
+
 				Int step = iconSize + iconSpacing;
-				Int bottomY = screenH - Int(40 * scale);
+
+				// Shift grid down by one row height (matches drawUnitQueuesImpl)
+				bottomY += step;
 
 				for (size_t ei = 0; ei < q.size(); ++ei)
 				{
@@ -8285,12 +8360,13 @@ void InGameUI::drawPlayerInfoList()
 					m_playerOverlayExt[slot].isPresent = false;
 				}
 
-				// Snapshot radar (minimap) right edge and right HUD left edge
+				// Snapshot UI element reference edges for queue alignment
 				Int radarRight = 0;
+				Int radarBottomY = 0;
 				Int rightHUDLeft = TheDisplay->getWidth();
 				if (TheWindowManager && TheNameKeyGenerator)
 				{
-					// Minimap / radar window
+					// Minimap / radar window (at bottom-left of screen)
 					GameWindow* radarWin = TheWindowManager->winGetWindowFromId(nullptr,
 						TheNameKeyGenerator->nameToKey("ControlBar.wnd:Radar"));
 					if (radarWin)
@@ -8298,11 +8374,12 @@ void InGameUI::drawPlayerInfoList()
 						IRegion2D radarRegion;
 						radarWin->winGetRegion(&radarRegion);
 						radarRight = radarRegion.hi.x;
+						radarBottomY = radarRegion.hi.y;
 						overlayLog("LAYOUT: radar region lo=(%d,%d) hi=(%d,%d)\n",
 							radarRegion.lo.x, radarRegion.lo.y, radarRegion.hi.x, radarRegion.hi.y);
 					}
 
-					// Right HUD / command panel (faction logo + power bar)
+					// Right HUD / command panel (for left-edge X reference only — Y is NOT at screen bottom)
 					GameWindow* rightHUD = TheWindowManager->winGetWindowFromId(nullptr,
 						TheNameKeyGenerator->nameToKey("ControlBar.wnd:RightHUD"));
 					if (rightHUD)
@@ -8315,19 +8392,21 @@ void InGameUI::drawPlayerInfoList()
 					}
 				}
 
-				// Store for use in draw: P1 between radar and scoreboard, P2 between scoreboard and right HUD
-				// Fallback: use screen-relative positions if windows not found
-				if (radarRight > 0)
-					m_queuePanelX[0] = radarRight + 4;  // small gap after minimap
-				else
-					m_queuePanelX[0] = Int(TheDisplay->getWidth() * 0.14f);
+				// Store raw reference edges — draw functions compute exact grid positions per-frame using scale
+				m_queuePanelX[0] = (radarRight > 0) ? radarRight : Int(TheDisplay->getWidth() * 0.14f);
+				m_queuePanelX[1] = (rightHUDLeft < TheDisplay->getWidth()) ? rightHUDLeft : Int(TheDisplay->getWidth() * 0.76f);
 
-				if (rightHUDLeft < TheDisplay->getWidth())
-					m_queuePanelX[1] = rightHUDLeft - 85; // queue width (3*27px) before right HUD
-				else
-					m_queuePanelX[1] = Int(TheDisplay->getWidth() * 0.76f);
-				overlayLog("LAYOUT: queue panel X: P1=%d P2=%d screenW=%d\n",
-					m_queuePanelX[0], m_queuePanelX[1], TheDisplay->getWidth());
+				// Both P1 and P2 use the same bottom Y from the radar (which is at the bottom of the screen)
+				// The rightHUD window is in the upper portion of the screen, so its hi.y is NOT suitable.
+				Int commonBottomY = (radarBottomY > 0) ? radarBottomY
+					: TheDisplay->getHeight() - Int(40 * (Real)TheDisplay->getWidth() / 1920.0f);
+				m_queuePanelBottomY[0] = commonBottomY;
+				m_queuePanelBottomY[1] = commonBottomY;
+
+				overlayLog("LAYOUT: queue refs: P1=(xRef=%d, botY=%d) P2=(xRef=%d, botY=%d) screenW=%d screenH=%d\n",
+					m_queuePanelX[0], m_queuePanelBottomY[0],
+					m_queuePanelX[1], m_queuePanelBottomY[1],
+					TheDisplay->getWidth(), TheDisplay->getHeight());
 			}
 
 			if (!localPlayer->isPlayerObserver() && !localPlayer->isPlayerDead())

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -31,6 +31,9 @@
 
 #define DEFINE_SHADOW_NAMES
 
+#include <cstdarg>  // TheSuperHackers: va_list for overlayLog
+#include <cstdio>    // TheSuperHackers: fopen/vfprintf for overlayLog
+
 #include "Common/ActionManager.h"
 #include "Common/FramePacer.h"
 #include "Common/GameAudio.h"
@@ -127,6 +130,87 @@ static Real safeGetPercentComplete(const ProductionEntry* entry) {
 static const ProductionEntry* safeNextProduction(ProductionUpdateInterface* prod, const ProductionEntry* entry) {
 	__try { return prod->nextProduction(const_cast<ProductionEntry*>(entry)); }
 	__except(EXCEPTION_EXECUTE_HANDLER) { return nullptr; }
+}
+static ProductionType safeGetProductionType(const ProductionEntry* entry) {
+	__try { return entry->getProductionType(); }
+	__except(EXCEPTION_EXECUTE_HANDLER) { return PRODUCTION_INVALID; }
+}
+#pragma warning(pop)
+
+// TheSuperHackers @feature 15/07/2026 Debug logging for overlay diagnostics
+static FILE* g_overlayLogFile = nullptr;
+static void overlayLog(const char* fmt, ...)
+{
+	__try {
+		if (!g_overlayLogFile) {
+			g_overlayLogFile = fopen("genovly_debug.log", "a");
+			
+			if (g_overlayLogFile) {
+				fprintf(g_overlayLogFile, "=== genovly overlay log started ===\n");
+				fflush(g_overlayLogFile);
+			}
+		}
+		if (g_overlayLogFile) {
+			va_list args;
+			va_start(args, fmt);
+			vfprintf(g_overlayLogFile, fmt, args);
+			va_end(args);
+			fflush(g_overlayLogFile);
+		}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		// Logging itself failed — silently ignore, don't crash the game
+	}
+}
+
+// TheSuperHackers @feature 15/07/2026 SEH-safe wrappers for overlay drawing calls.
+// These ensure the game never crashes due to overlay rendering failures.
+#pragma warning(push)
+#pragma warning(disable: 4611)
+static void safeDrawUnitQueues(InGameUI* ui, Int baseX, Int baseY, Int lineH, Real scale)
+{
+	__try {
+		ui->drawUnitQueuesImpl(baseX, baseY, lineH, scale);
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		overlayLog("SEH CRASH in drawUnitQueues — caught, game continues\n");
+	}
+}
+static void safeDrawPowerCooldowns(InGameUI* ui, Int baseX, Int baseY, Int lineH, Real scale)
+{
+	__try {
+		ui->drawPowerCooldownsImpl(baseX, baseY, lineH, scale);
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		overlayLog("SEH CRASH in drawPowerCooldowns — caught, game continues\n");
+	}
+}
+static void safeDrawPowerFlashes(InGameUI* ui)
+{
+	__try {
+		ui->drawPowerFlashesImpl();
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		overlayLog("SEH CRASH in drawPowerFlashes — caught, game continues\n");
+	}
+}
+static void safeDrawUnitQueueClicks(InGameUI* ui)
+{
+	__try {
+		ui->drawUnitQueueClicksImpl();
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		overlayLog("SEH CRASH in drawUnitQueueClicks — caught, game continues\n");
+	}
+}
+static void safeGatherOverlayExtData(InGameUI* ui)
+{
+	__try {
+		ui->gatherOverlayExtDataImpl();
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		overlayLog("SEH CRASH in gatherOverlayExtData — caught, game continues\n");
+	}
 }
 #pragma warning(pop)
 
@@ -3911,6 +3995,9 @@ void InGameUI::postWindowDraw()
 	hudOffsetX = 0;
 	hudOffsetY += 250;
 
+	// TheSuperHackers @feature 15/07/2026 Overlay (queues + powers) always runs regardless of stats font size.
+	drawOverlayExt();
+
 	if (m_observerStatsPointSize > 0)
 		drawObserverStats(hudOffsetX, hudOffsetY);
 
@@ -6545,6 +6632,8 @@ void InGameUI::notifySpecialPowerUsed(Player* player, const SpecialPowerTemplate
 
 void InGameUI::drawObserverStats(Int & x, Int & y)
 {
+	overlayLog("OBS: drawObserverStats called\n");
+
 	// do we need to re-create our fonts?
 	if (m_observerStatsPointSize != TheGlobalData->m_observerStatsFontSize)
 	{
@@ -6564,18 +6653,20 @@ void InGameUI::drawObserverStats(Int & x, Int & y)
 
 	Player* localPlayer = ThePlayerList->getLocalPlayer();
 	if (!localPlayer || (TheGameLogic && TheGameLogic->getFrame() <= 1))
+	{
+		overlayLog("OBS: early return — no localPlayer or frame<=1\n");
 		return;
+	}
 
 		if (!localPlayer->isPlayerObserver() && !localPlayer->isPlayerDead())
+		{
+			overlayLog("OBS: early return — not observer and not dead (observer=%d dead=%d)\n",
+					(Int)localPlayer->isPlayerObserver(), (Int)localPlayer->isPlayerDead());
 			return;
-
-		// TheSuperHackers @feature 14/07/2026 Gather overlay extension data for unit queues and powers
-		// Delay 60 frames (1s) to let replay mode fully initialize game state
-		if (TheGameLogic && TheGameLogic->getFrame() >= 60)
-			gatherOverlayExtData();
+		}
 
 		if (!isAtHudAnchorPos(m_observerStatsPosition) || m_observerStatsHidden)
-		return;
+			return;
 
 	// couldn't allocate memory, early out
 	if (m_observerStatsString == nullptr)
@@ -6800,17 +6891,6 @@ void InGameUI::drawObserverStats(Int & x, Int & y)
     Int rowSpacing = Int(2 * scale);
 
 	totalHeight = (lineHeight + rowSpacing) * (1 + Int(actualNumPlayers));
-
-	// TheSuperHackers @feature 14/07/2026 Draw unit queues and power cooldowns
-	// Compute positions independently of stats table (may be empty in replay mode)
-	{	Int queueBaseY = screenH - Int(80 * scale);
-		if (queueBaseY < 0) queueBaseY = 0;
-		Int queueLineH = Int(18 * scale);
-		if (queueLineH < 1) queueLineH = 1;
-		drawUnitQueues(Int(10 * scale), queueBaseY, queueLineH, scale);
-		drawPowerCooldowns(Int(10 * scale), queueBaseY, queueLineH, scale);
-		drawPowerFlashes();
-	}
 
 	if (actualNumPlayers == 0)
 		return;
@@ -7422,54 +7502,81 @@ void InGameUI::drawPlayerInfoList()
 		// =================================================================================================
 
 				void InGameUI::collectQueueEntries(Object* obj, void* userData)
-				{
-					if (!obj) return;
-					const ThingTemplate* tmpl = obj->getTemplate();
-					if (!tmpl) return;
+		{
+			if (!obj) return;
+			const ThingTemplate* tmpl = obj->getTemplate();
+			if (!tmpl) return;
 
-					// TheSuperHackers @test step 2: only check building type
-					InGameUI::BuildingType bt = InGameUI::BUILDING_COUNT;
-					AsciiString name = tmpl->getName();
-					if (name.endsWith("WarFactory"))       bt = InGameUI::BUILDING_WAR_FACTORY;
-					else if (name.endsWith("Barracks"))     bt = InGameUI::BUILDING_BARRACKS;
-					else if (name.endsWith("AirField"))     bt = InGameUI::BUILDING_AIRFIELD;
-					if (bt == InGameUI::BUILDING_COUNT) return;
+			// Match any production building (War Factory, Barracks, Airfield)
+			AsciiString name = tmpl->getName();
+			Bool isProdBuilding = name.endsWith("WarFactory") || name.endsWith("Barracks") || name.endsWith("AirField") || name.endsWith("CommandCenter");
+			if (!isProdBuilding) return;
 
-					// TheSuperHackers @test step 3: try production module access
-					ProductionUpdateInterface* prod = (ProductionUpdateInterface*)obj->findUpdateModule(
-						TheNameKeyGenerator->nameToKey("ProductionUpdate"));
-					if (!prod || safeGetProductionCount(prod) == 0) return;
+			overlayLog("COLLECT: found building %s\n", name.str());
 
-										// TheSuperHackers @test step 4: slot-finding loop
-										Int slot = -1;
-										for (Int s = 0; s < MAX_SLOTS; ++s)
-					{
-						AsciiString nsk;
-						nsk.format("player%d", s);
-						Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
-						if (pp && obj->getControllingPlayer() == pp) { slot = s; break; }
-					}
-					if (slot < 0) return;
+			// Get the world position of this building for future click-to-navigate.
+			// In replay mode getPosition() may return nullptr — use zero vec as fallback.
+			Coord3D buildingPos = { 0, 0, 0 };
+			const Coord3D* pos = obj->getPosition();
+			if (pos) buildingPos = *pos;
 
-					// TheSuperHackers @fix: production entry traversal can crash in replay mode (corrupted linked list).
-					// Use safe wrapper functions that handle the crash gracefully.
-					InGameUI* ui = (InGameUI*)userData;
-					InGameUI::PlayerOverlayExt& ext = ui->m_playerOverlayExt[slot];
-					const ProductionEntry* entry = safeFirstProduction(prod);
-					Int count = 0;
-					while (entry && count < InGameUI::MAX_VISIBLE_QUEUE)
-					{
-						if (entry->getProductionType() == PRODUCTION_UNIT)
-						{
-							InGameUI::QueueEntry qe;
-							qe.tmpl = safeGetProductionObject(entry);
-							qe.percentComplete = safeGetPercentComplete(entry);
-							ext.queue[bt].push_back(qe);
-							++count;
-						}
-						entry = safeNextProduction(prod, entry);
-					}
+			// TheSuperHackers @test step 3: try production module access
+			ProductionUpdateInterface* prod = (ProductionUpdateInterface*)obj->findUpdateModule(
+				TheNameKeyGenerator->nameToKey("ProductionUpdate"));
+			if (!prod) { overlayLog("COLLECT: %s has NO ProductionUpdate module\n", name.str()); return; }
+			UnsignedInt prodCount = safeGetProductionCount(prod);
+			if (prodCount == 0) { overlayLog("COLLECT: %s prodCount=0\n", name.str()); return; }
+			overlayLog("COLLECT: %s prodCount=%u\n", name.str(), prodCount);
+
+			// TheSuperHackers @test step 4: slot-finding loop
+			Int slot = -1;
+			for (Int s = 0; s < MAX_SLOTS; ++s)
+			{
+				AsciiString nsk;
+				nsk.format("player%d", s);
+				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+				if (pp && obj->getControllingPlayer() == pp) { slot = s; break; }
 			}
+			if (slot < 0) { overlayLog("COLLECT: %s slot not found\n", name.str()); return; }
+
+			InGameUI* ui = (InGameUI*)userData;
+			InGameUI::PlayerOverlayExt& ext = ui->m_playerOverlayExt[slot];
+
+			const ProductionEntry* entry = safeFirstProduction(prod);
+			if (!entry) {
+				overlayLog("COLLECT: %s slot=%d firstProduction=nullptr (prodCount=%u) — replay mode, linked list not restored\n",
+					name.str(), slot, prodCount);
+				// Fallback: push a single placeholder entry with just the building info
+				InGameUI::QueueEntry qe;
+				qe.tmpl = tmpl;  // use building template so we get the building icon
+				qe.percentComplete = 0.0f;
+				qe.buildingPos = buildingPos;
+				qe.buildingName = name;
+				ext.queue.push_back(qe);
+				return;
+			}
+
+			while (entry)
+			{
+				ProductionType pt = safeGetProductionType(entry);
+				overlayLog("COLLECT: %s entry type=%d\n", name.str(), (Int)pt);
+				if (pt == PRODUCTION_UNIT)
+				{
+					InGameUI::QueueEntry qe;
+					qe.tmpl = safeGetProductionObject(entry);
+					qe.percentComplete = safeGetPercentComplete(entry);
+					qe.buildingPos = buildingPos;
+					qe.buildingName = name;
+					ext.queue.push_back(qe);
+
+					overlayLog("Queue: slot=%d building=%s unit=%s pct=%.0f%%\n",
+						slot, name.str(),
+						qe.tmpl ? qe.tmpl->getName().str() : "NULL",
+						qe.percentComplete);
+				}
+				entry = safeNextProduction(prod, entry);
+			}
+		}
 	
 			// Helper: find special power module for one power slot
 		void InGameUI::findPowerModule(Object* obj, void* userData)
@@ -7559,20 +7666,175 @@ void InGameUI::drawPlayerInfoList()
 			}
 		}
 
-		void InGameUI::gatherOverlayExtData()
+		// TheSuperHackers @feature 15/07/2026 Shadow queue: called from ProductionUpdate::queueCreateUnit hook.
+		// Builds queue entries from actual game events — works in both live and replay mode.
+		void InGameUI::onUnitQueued(Player* player, const ThingTemplate* unitType, Object* producer, Real percentComplete)
+		{
+			if (!player || !unitType || !producer || !ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			if (!m_isValid1v1)
+				return;
+
+			// Find which slot this player is in
+			Int slot = -1;
+			for (Int s = 0; s < MAX_SLOTS; ++s)
+			{
+				AsciiString nsk;
+				nsk.format("player%d", s);
+				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+				if (pp == player) { slot = s; break; }
+			}
+			if (slot < 0 || slot >= MAX_SLOTS) return;
+			if (!m_playerOverlayExt[slot].isPresent) return;
+
+			// Get building position
+			const Coord3D* pos = producer->getPosition();
+			Coord3D buildingPos = { 0, 0, 0 };
+			if (pos) buildingPos = *pos;
+
+			// Get building name
+			AsciiString buildingName;
+			const ThingTemplate* btmpl = producer->getTemplate();
+			if (btmpl) buildingName = btmpl->getName();
+
+			// Push into the player's queue
+			QueueEntry qe;
+			qe.tmpl = unitType;
+			qe.percentComplete = percentComplete;
+			qe.buildingPos = buildingPos;
+			qe.buildingName = buildingName;
+			qe.producer = producer;
+			m_playerOverlayExt[slot].queue.push_back(qe);
+
+			overlayLog("QUEUED: slot=%d building=%s unit=%s pct=%.0f%%\n",
+				slot, buildingName.str(),
+				unitType ? unitType->getName().str() : "NULL",
+				percentComplete);
+		}
+
+		// TheSuperHackers @feature 15/07/2026 Called from ProductionUpdate::update hook.
+		// Removes the completed unit from the shadow queue.
+		void InGameUI::onUnitCompleted(Player* player, const ThingTemplate* unitType, Object* producer)
+		{
+			if (!player || !unitType || !producer || !ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			Int slot = -1;
+			for (Int s = 0; s < MAX_SLOTS; ++s)
+			{
+				AsciiString nsk;
+				nsk.format("player%d", s);
+				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+				if (pp == player) { slot = s; break; }
+			}
+			if (slot < 0 || slot >= MAX_SLOTS) return;
+
+			std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
+
+			for (size_t i = 0; i < q.size(); ++i)
+			{
+				if (q[i].producer == producer && q[i].tmpl == unitType)
+				{
+					overlayLog("COMPLETED: slot=%d building=%s unit=%s removed\n",
+						slot, q[i].buildingName.str(),
+						unitType->getName().str());
+					q.erase(q.begin() + i);
+					return;
+				}
+			}
+		}
+
+		// TheSuperHackers @feature 15/07/2026 Called from ProductionUpdate::cancelUnitCreate hook.
+		// Removes the matching entry from the shadow queue.
+		void InGameUI::onUnitCancelled(Player* player, const ThingTemplate* unitType, Object* producer)
+		{
+			if (!player || !unitType || !producer || !ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			// Find which slot this player is in
+			Int slot = -1;
+			for (Int s = 0; s < MAX_SLOTS; ++s)
+			{
+				AsciiString nsk;
+				nsk.format("player%d", s);
+				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+				if (pp == player) { slot = s; break; }
+			}
+			if (slot < 0 || slot >= MAX_SLOTS) return;
+
+			std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
+
+			// Find and remove the first matching entry (same building instance, same unit type)
+			for (size_t i = 0; i < q.size(); ++i)
+			{
+				if (q[i].producer == producer && q[i].tmpl == unitType)
+				{
+					overlayLog("CANCEL: slot=%d building=%s unit=%s removed\n",
+						slot, q[i].buildingName.str(),
+						unitType->getName().str());
+					q.erase(q.begin() + i);
+					return;
+				}
+			}
+		}
+
+		// TheSuperHackers @feature 15/07/2026 Called from ProductionUpdate::onDie hook.
+		// Removes ALL queued units for a destroyed/sold building (bypasses corrupt linked list in replay).
+		void InGameUI::onBuildingDestroyed(Object* producer)
+		{
+			if (!producer) return;
+
+			// Search all player slots for entries from this building instance and remove them
+			for (Int slot = 0; slot < MAX_SLOTS; ++slot)
+			{
+				std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
+				for (size_t i = 0; i < q.size(); )
+				{
+					if (q[i].producer == producer)
+					{
+						overlayLog("DESTROYED: slot=%d building=%s unit=%s removed\n",
+							slot, q[i].buildingName.str(),
+							q[i].tmpl ? q[i].tmpl->getName().str() : "NULL");
+						q.erase(q.begin() + i);
+						// don't increment i — erase shifts elements
+					}
+					else
+					{
+						++i;
+					}
+				}
+			}
+		}
+
+		void InGameUI::gatherOverlayExtDataImpl()
 		{
 			if (!TheGameLogic || !ThePlayerList || !TheNameKeyGenerator)
+			{
+				overlayLog("GATHER: early return — null globals\n");
 				return;
+			}
 
 			UnsignedInt currentFrame = TheGameLogic ? TheGameLogic->getFrame() : 0;
 			UnsignedInt flashWindow = (UnsignedInt)(LOGICFRAMES_PER_SECOND * 3); // 3 seconds
+			Bool isReplay = (TheRecorder && TheRecorder->isPlaybackMode());
 
 			// Resolve the two 1v1 player slots
 			resolveOverlayPlayers();
 
-			// Clear all overlay ext slots first
-			for (Int slot = 0; slot < MAX_SLOTS; ++slot)
-				m_playerOverlayExt[slot].isPresent = false;
+			overlayLog("GATHER: frame=%u isValid=%d slots=[%d,%d]\n",
+				currentFrame, (Int)m_isValid1v1,
+				m_overlayPlayerSlots[0], m_overlayPlayerSlots[1]);
+
+			// Clear all overlay ext slots first (only in live mode — replay uses shadow queue)
+			if (!isReplay)
+			{
+				for (Int slot = 0; slot < MAX_SLOTS; ++slot)
+				{
+					m_playerOverlayExt[slot].isPresent = false;
+					m_playerOverlayExt[slot].queue.clear();
+				}
+			}
 
 			if (!m_isValid1v1)
 				return;
@@ -7597,10 +7859,20 @@ void InGameUI::drawPlayerInfoList()
 				}
 
 				// ---- Unit queues ----
-				for (Int bt = 0; bt < BUILDING_COUNT; ++bt)
-															m_playerOverlayExt[slot].queue[bt].clear();
-
-														p->iterateObjects(collectQueueEntries, this);
+				// In replay mode, the linked list is not restored — use the shadow queue
+				// built by the onUnitQueued hook in ProductionUpdate::queueCreateUnit.
+				if (!isReplay)
+				{
+					m_playerOverlayExt[slot].queue.clear();
+					overlayLog("GATHER: about to iterateObjects for slot=%d (live mode)\n", slot);
+					p->iterateObjects(collectQueueEntries, this);
+					overlayLog("GATHER: done iterateObjects slot=%d queueSize=%zu\n", slot, m_playerOverlayExt[slot].queue.size());
+				}
+				else
+				{
+					// Replay mode: queue is built by onUnitQueued hook — don't clear it
+					overlayLog("GATHER: replay mode slot=%d queueSize=%zu (shadow queue)\n", slot, m_playerOverlayExt[slot].queue.size());
+				}
 
 														// ---- General power cooldowns ----
 				const PlayerTemplate* pt = p->getPlayerTemplate();
@@ -7678,13 +7950,16 @@ void InGameUI::drawPlayerInfoList()
 			}
 		}
 
-		void InGameUI::drawUnitQueues(Int baseX, Int baseY, Int lineH, Real scale)
+		void InGameUI::drawUnitQueuesImpl(Int baseX, Int baseY, Int lineH, Real scale)
 		{
 			if (!TheDisplay || !m_isValid1v1) return;
 
-			Int iconSize = Int(20 * scale);
-			Int iconSpacing = Int(2 * scale);
-			Int startX = baseX;
+			overlayLog("DRAW_Q: entry valid1v1=%d\n", (Int)m_isValid1v1);
+
+			Int screenW = TheDisplay->getWidth();
+			Int screenH = TheDisplay->getHeight();
+			Int iconSize = Int(24 * scale);
+			Int iconSpacing = Int(3 * scale);
 
 			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
 			{
@@ -7692,37 +7967,64 @@ void InGameUI::drawPlayerInfoList()
 				if (slot < 0 || slot >= MAX_SLOTS) continue;
 				if (!m_playerOverlayExt[slot].isPresent) continue;
 
-				Int rowY = baseY + (ovIdx + 1) * lineH;
-				for (Int bt = 0; bt < BUILDING_COUNT; ++bt)
-				{
-					const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue[bt];
-					if (q.empty()) continue;
+				const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
+				overlayLog("DRAW_Q: player slot=%d ovIdx=%d queueSize=%zu\n", slot, ovIdx, q.size());
+				if (q.empty()) continue;
 
-					Int iconX = startX;
-					for (size_t ei = 0; ei < q.size(); ++ei)
+				// Position: P1 left of scoreboard, P2 right of scoreboard (above command panel)
+				// Layout: max 3 icons per row, expanding upward from bottom
+				Int panelX;
+				if (ovIdx == 0)
+					panelX = Int(screenW * 0.17f);  // between minimap and scoreboard
+				else
+					panelX = Int(screenW * 0.75f);  // between scoreboard and command panel
+
+				static const Int MAX_COLS = 3;
+				Int startY = screenH - Int(200 * scale); // above bottom UI bar
+				if (startY < 0) startY = 0;
+
+				for (size_t ei = 0; ei < q.size(); ++ei)
+				{
+					Int col = (Int)(ei % MAX_COLS);
+					Int row = (Int)(ei / MAX_COLS);
+					Int ix = panelX + col * (iconSize + iconSpacing);
+					Int iy = startY - row * (iconSize + iconSpacing);
+
+					// Try drawing the button image first
+					if (q[ei].tmpl && q[ei].tmpl->getButtonImage())
 					{
-						if (q[ei].tmpl && q[ei].tmpl->getButtonImage())
-						{
-							const Image* img = q[ei].tmpl->getButtonImage();
-							TheDisplay->drawImage(img, iconX, rowY, iconX + iconSize, rowY + iconSize);
-							// Draw progress bar at bottom of icon
-							Int progW = (Int)(iconSize * q[ei].percentComplete / 100.0f);
-							if (progW > 0)
-								TheWindowManager->winFillRect(
-									TheWindowManager->winMakeColor(0, 200, 0, 180), 1,
-									iconX, rowY + iconSize - 3, iconX + progW, rowY + iconSize);
-						}
-						iconX += iconSize + iconSpacing;
-						if (iconX > startX + 150) break;
+						const Image* img = q[ei].tmpl->getButtonImage();
+						TheDisplay->drawImage(img, ix, iy,
+							ix + iconSize, iy + iconSize);
 					}
-					rowY += iconSize + iconSpacing;
+					else
+					{
+						// Fallback: gray rectangle placeholder
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(60, 60, 60, 200), 1,
+							ix, iy,
+							ix + iconSize, iy + iconSize);
+					}
+
+					// Green progress bar at bottom of icon
+					if (q[ei].percentComplete > 0.0f)
+					{
+						Int progW = (Int)(iconSize * q[ei].percentComplete / 100.0f);
+						if (progW < 1) progW = 1;
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(0, 200, 0, 200), 1,
+							ix, iy + iconSize - 3,
+							ix + progW, iy + iconSize);
+					}
 				}
 			}
 		}
 
-		void InGameUI::drawPowerCooldowns(Int baseX, Int baseY, Int lineH, Real scale)
+		void InGameUI::drawPowerCooldownsImpl(Int baseX, Int baseY, Int lineH, Real scale)
 		{
 			if (!TheGameLogic || !m_isValid1v1) return;
+
+			overlayLog("DRAW_P: entry valid1v1=%d\n", (Int)m_isValid1v1);
 
 			UnsignedInt currentFrame = TheGameLogic->getFrame();
 			Int ringSize = Int(44 * scale);
@@ -7825,11 +8127,13 @@ void InGameUI::drawPlayerInfoList()
 			}
 		}
 
-		void InGameUI::drawPowerFlashes()
+		void InGameUI::drawPowerFlashesImpl()
 		{
 			// Click-to-navigate: check if mouse clicked on a power icon
 			if (!TheDisplay || !TheMouse || !TheTacticalView || !m_isValid1v1)
 				return;
+
+			overlayLog("DRAW_F: entry valid1v1=%d\n", (Int)m_isValid1v1);
 			if (!TheGameLogic)
 				return;
 
@@ -7896,5 +8200,132 @@ void InGameUI::drawPlayerInfoList()
 			}
 		}
 
-		// @todo notifyGeneralPromotion and notifySpecialPowerUsed are already implemented above
-		// (they are observer notification functions, not overlay data functions).
+		void InGameUI::drawUnitQueueClicksImpl()
+		{
+			// Click-to-navigate: check if mouse clicked on a queue icon
+			if (!TheDisplay || !TheMouse || !TheTacticalView || !m_isValid1v1)
+				return;
+
+			const MouseIO* mouse = TheMouse->getMouseStatus();
+			if (!mouse)
+				return;
+
+			// Only handle on the frame the left button is first pressed down
+			if (mouse->leftState != MBS_Down)
+				return;
+
+			Int mx = mouse->pos.x;
+			Int my = mouse->pos.y;
+
+			Int screenW = TheDisplay->getWidth();
+			Int screenH = TheDisplay->getHeight();
+			Real scale = (Real)screenW / 1920.0f;
+			scale = (scale < 0.7f) ? 0.7f : (scale > 2.0f) ? 2.0f : scale;
+			Int iconSize = Int(24 * scale);
+			Int iconSpacing = Int(3 * scale);
+
+			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
+			{
+				Int slot = m_overlayPlayerSlots[ovIdx];
+				if (slot < 0 || slot >= MAX_SLOTS) continue;
+				if (!m_playerOverlayExt[slot].isPresent) continue;
+
+				const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
+				if (q.empty()) continue;
+
+				// Must match drawUnitQueuesImpl layout
+				Int panelX;
+				if (ovIdx == 0)
+					panelX = Int(screenW * 0.17f);
+				else
+					panelX = Int(screenW * 0.75f);
+
+				static const Int MAX_COLS = 3;
+				Int startY = screenH - Int(200 * scale);
+				if (startY < 0) startY = 0;
+
+				for (size_t ei = 0; ei < q.size(); ++ei)
+				{
+					Int col = (Int)(ei % MAX_COLS);
+					Int row = (Int)(ei / MAX_COLS);
+					Int ix = panelX + col * (iconSize + iconSpacing);
+					Int iy = startY - row * (iconSize + iconSpacing);
+
+					if (mx >= ix && mx <= ix + iconSize &&
+						my >= iy && my <= iy + iconSize)
+					{
+						// Clicked on this queue icon — navigate to the production building
+						if (q[ei].buildingPos.x != 0.0f || q[ei].buildingPos.y != 0.0f)
+						{
+							TheTacticalView->lookAt(&q[ei].buildingPos);
+						}
+						return;
+					}
+				}
+			}
+		}
+
+		// TheSuperHackers @feature 15/07/2026 Standalone overlay draw — always safe, never depends on stats font.
+		void InGameUI::drawOverlayExt()
+		{
+			if (!TheDisplay || !TheGameLogic || !ThePlayerList)
+				return;
+
+			Player* localPlayer = ThePlayerList->getLocalPlayer();
+			if (!localPlayer || TheGameLogic->getFrame() <= 1)
+				return;
+
+			// Reset shadow queues on new game/replay start (frame 2 is the first real frame)
+			if (TheGameLogic->getFrame() == 2)
+			{
+				for (Int slot = 0; slot < MAX_SLOTS; ++slot)
+				{
+					m_playerOverlayExt[slot].queue.clear();
+					m_playerOverlayExt[slot].isPresent = false;
+				}
+			}
+
+			if (!localPlayer->isPlayerObserver() && !localPlayer->isPlayerDead())
+				return;
+
+			// Delay 60 frames (1s) to let replay mode fully initialize game state
+			if (TheGameLogic->getFrame() >= 60)
+				safeGatherOverlayExtData(this);
+
+			Int screenW = TheDisplay->getWidth();
+			Int screenH = TheDisplay->getHeight();
+			Real scale = (Real)screenW / 1920.0f;
+			scale = (scale < 0.7f) ? 0.7f : (scale > 2.0f) ? 2.0f : scale;
+
+			Int queueBaseY = screenH - Int(80 * scale);
+			if (queueBaseY < 0) queueBaseY = 0;
+			Int queueLineH = Int(18 * scale);
+			if (queueLineH < 1) queueLineH = 1;
+			safeDrawUnitQueues(this, Int(10 * scale), queueBaseY, queueLineH, scale);
+			safeDrawPowerCooldowns(this, Int(10 * scale), queueBaseY, queueLineH, scale);
+			safeDrawPowerFlashes(this);
+			safeDrawUnitQueueClicks(this);
+		}
+
+		// TheSuperHackers @feature 15/07/2026 Public wrappers — delegate to SEH-safe static helpers.
+		// These keep the existing public API but protect against crashes in the overlay code.
+		void InGameUI::gatherOverlayExtData()
+		{
+			safeGatherOverlayExtData(this);
+		}
+		void InGameUI::drawUnitQueues(Int baseX, Int baseY, Int lineH, Real scale)
+		{
+			safeDrawUnitQueues(this, baseX, baseY, lineH, scale);
+		}
+		void InGameUI::drawPowerCooldowns(Int baseX, Int baseY, Int lineH, Real scale)
+		{
+			safeDrawPowerCooldowns(this, baseX, baseY, lineH, scale);
+		}
+		void InGameUI::drawPowerFlashes()
+		{
+			safeDrawPowerFlashes(this);
+		}
+		void InGameUI::drawUnitQueueClicks()
+		{
+			safeDrawUnitQueueClicks(this);
+		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7480,14 +7480,8 @@ void InGameUI::drawPlayerInfoList()
 			SpecialPowerModuleInterface* mod = obj->getSpecialPowerModule(info->button->getSpecialPowerTemplate());
 			if (mod)
 			{
-				// Only count this module if the building is fully built.
-				// Buildings under construction return 0..100; CONSTRUCTION_COMPLETE = -1 means done.
-				Real constPct = obj->getConstructionPercent();
-				if (constPct == CONSTRUCTION_COMPLETE || constPct >= 100.0f)
-				{
-					info->hasModule = true;
-					info->readyFrame = mod->getReadyFrame();
-				}
+				info->hasModule = true;
+				info->readyFrame = mod->getReadyFrame();
 			}
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7972,7 +7972,8 @@ void InGameUI::drawPlayerInfoList()
 				if (q.empty()) continue;
 
 				// Position: P1 left of scoreboard, P2 right of scoreboard (above command panel)
-				// Layout: max 3 icons per row, expanding upward from bottom
+				// Layout: max 3 columns per row, filling top→bottom, pinned to screen bottom
+				// Only the last 3 rows are visible; older rows scroll off below viewport
 				Int panelX;
 				if (ovIdx == 0)
 					panelX = Int(screenW * 0.17f);  // between minimap and scoreboard
@@ -7980,15 +7981,25 @@ void InGameUI::drawPlayerInfoList()
 					panelX = Int(screenW * 0.75f);  // between scoreboard and command panel
 
 				static const Int MAX_COLS = 3;
-				Int startY = screenH - Int(200 * scale); // above bottom UI bar
-				if (startY < 0) startY = 0;
+				static const Int MAX_VISIBLE_ROWS = 3;
+				Int step = iconSize + iconSpacing;
+				Int bottomMargin = Int(20 * scale);  // tight against bottom edge
+				Int bottomY = screenH - bottomMargin;
+
+				Int totalRows = (Int)((q.size() + MAX_COLS - 1) / MAX_COLS);
+				Int visibleRows = (totalRows < MAX_VISIBLE_ROWS) ? totalRows : MAX_VISIBLE_ROWS;
+				Int skipRows = totalRows - visibleRows;  // rows above viewport (older)
 
 				for (size_t ei = 0; ei < q.size(); ++ei)
 				{
-					Int col = (Int)(ei % MAX_COLS);
 					Int row = (Int)(ei / MAX_COLS);
-					Int ix = panelX + col * (iconSize + iconSpacing);
-					Int iy = startY - row * (iconSize + iconSpacing);
+					Int visibleRow = row - skipRows;
+					if (visibleRow < 0) continue;  // above viewport → skip
+
+					Int col = (Int)(ei % MAX_COLS);
+					Int ix = panelX + col * step;
+					// visibleRow 0 = top of visible area, visibleRow 2 = bottom (against screen edge)
+					Int iy = bottomY - (MAX_VISIBLE_ROWS - visibleRow) * step;
 
 					// Try drawing the button image first
 					if (q[ei].tmpl && q[ei].tmpl->getButtonImage())
@@ -8233,7 +8244,7 @@ void InGameUI::drawPlayerInfoList()
 				const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
 				if (q.empty()) continue;
 
-				// Must match drawUnitQueuesImpl layout
+				// Must match drawUnitQueuesImpl layout (bottom-pinned, 3 rows visible, top→bottom fill)
 				Int panelX;
 				if (ovIdx == 0)
 					panelX = Int(screenW * 0.17f);
@@ -8241,15 +8252,24 @@ void InGameUI::drawPlayerInfoList()
 					panelX = Int(screenW * 0.75f);
 
 				static const Int MAX_COLS = 3;
-				Int startY = screenH - Int(200 * scale);
-				if (startY < 0) startY = 0;
+				static const Int MAX_VISIBLE_ROWS = 3;
+				Int step = iconSize + iconSpacing;
+				Int bottomMargin = Int(20 * scale);
+				Int bottomY = screenH - bottomMargin;
+
+				Int totalRows = (Int)((q.size() + MAX_COLS - 1) / MAX_COLS);
+				Int visibleRows = (totalRows < MAX_VISIBLE_ROWS) ? totalRows : MAX_VISIBLE_ROWS;
+				Int skipRows = totalRows - visibleRows;
 
 				for (size_t ei = 0; ei < q.size(); ++ei)
 				{
-					Int col = (Int)(ei % MAX_COLS);
 					Int row = (Int)(ei / MAX_COLS);
-					Int ix = panelX + col * (iconSize + iconSpacing);
-					Int iy = startY - row * (iconSize + iconSpacing);
+					Int visibleRow = row - skipRows;
+					if (visibleRow < 0) continue;
+
+					Int col = (Int)(ei % MAX_COLS);
+					Int ix = panelX + col * step;
+					Int iy = bottomY - (MAX_VISIBLE_ROWS - visibleRow) * step;
 
 					if (mx >= ix && mx <= ix + iconSize &&
 						my >= iy && my <= iy + iconSize)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7811,11 +7811,27 @@ void InGameUI::drawPlayerInfoList()
 		// TheSuperHackers @feature 17/07/2026 Shadow upgrade queue: called from ProductionUpdate::queueUpgrade hook.
 		void InGameUI::onUpgradeQueued(Player* player, const UpgradeTemplate* upgradeType, Object* producer, Real percentComplete)
 		{
+
+			// TheSuperHackers @debug 17/07/2026 H2: does the hook fire but get filtered by an early return?
+			overlayLog("UPGRADE_HOOK: onUpgradeQueued entry frame=%d replay=%d isValid1v1=%d player=%p upgrade=%s producer=%p pct=%.0f%%\n",
+				TheGameLogic ? (Int)TheGameLogic->getFrame() : -1,
+				(TheRecorder && TheRecorder->isPlaybackMode()) ? 1 : 0,
+				m_isValid1v1 ? 1 : 0,
+				(void*)player,
+				upgradeType ? upgradeType->getUpgradeName().str() : "NULL",
+				(void*)producer,
+				percentComplete);
 			if (!player || !upgradeType || !producer || !ThePlayerList || !TheNameKeyGenerator)
+			{
+				overlayLog("UPGRADE_HOOK: onUpgradeQueued early-return reason=null_ptr\n");
 				return;
+			}
 
 			if (!m_isValid1v1)
+			{
+				overlayLog("UPGRADE_HOOK: onUpgradeQueued early-return reason=invalid_1v1\n");
 				return;
+			}
 
 			Int slot = -1;
 			for (Int s = 0; s < MAX_SLOTS; ++s)
@@ -7825,8 +7841,16 @@ void InGameUI::drawPlayerInfoList()
 				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
 				if (pp == player) { slot = s; break; }
 			}
-			if (slot < 0 || slot >= MAX_SLOTS) return;
-			if (!m_playerOverlayExt[slot].isPresent) return;
+			if (slot < 0 || slot >= MAX_SLOTS)
+			{
+				overlayLog("UPGRADE_HOOK: onUpgradeQueued early-return reason=slot_not_found player=%p\n", (void*)player);
+				return;
+			}
+			if (!m_playerOverlayExt[slot].isPresent)
+			{
+				overlayLog("UPGRADE_HOOK: onUpgradeQueued early-return reason=slot_not_present slot=%d\n", slot);
+				return;
+			}
 
 			const Coord3D* pos = producer->getPosition();
 			Coord3D buildingPos = { 0, 0, 0 };
@@ -7853,6 +7877,14 @@ void InGameUI::drawPlayerInfoList()
 		// TheSuperHackers @feature 17/07/2026 Called from ProductionUpdate::update hook (upgrade completion).
 		void InGameUI::onUpgradeCompleted(Player* player, const UpgradeTemplate* upgradeType, Object* producer)
 		{
+
+			// TheSuperHackers @debug 17/07/2026 H3: does onUpgradeCompleted fire (possibly same frame as queued)?
+			overlayLog("UPGRADE_HOOK: onUpgradeCompleted entry frame=%d replay=%d player=%p upgrade=%s producer=%p\n",
+				TheGameLogic ? (Int)TheGameLogic->getFrame() : -1,
+				(TheRecorder && TheRecorder->isPlaybackMode()) ? 1 : 0,
+				(void*)player,
+				upgradeType ? upgradeType->getUpgradeName().str() : "NULL",
+				(void*)producer);
 			if (!player || !upgradeType || !producer || !ThePlayerList || !TheNameKeyGenerator)
 				return;
 
@@ -7884,6 +7916,14 @@ void InGameUI::drawPlayerInfoList()
 		// TheSuperHackers @feature 17/07/2026 Called from ProductionUpdate::cancelUpgrade hook.
 		void InGameUI::onUpgradeCancelled(Player* player, const UpgradeTemplate* upgradeType, Object* producer)
 		{
+
+			// TheSuperHackers @debug 17/07/2026 H3: does onUpgradeCancelled fire (possibly same frame as queued)?
+			overlayLog("UPGRADE_HOOK: onUpgradeCancelled entry frame=%d replay=%d player=%p upgrade=%s producer=%p\n",
+				TheGameLogic ? (Int)TheGameLogic->getFrame() : -1,
+				(TheRecorder && TheRecorder->isPlaybackMode()) ? 1 : 0,
+				(void*)player,
+				upgradeType ? upgradeType->getUpgradeName().str() : "NULL",
+				(void*)producer);
 			if (!player || !upgradeType || !producer || !ThePlayerList || !TheNameKeyGenerator)
 				return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1408,6 +1408,8 @@ InGameUI::InGameUI()
 		m_isValid1v1 = false;
 		m_overlayPlayerSlots[0] = -1;
 		m_overlayPlayerSlots[1] = -1;
+		m_queuePanelX[0] = 0;
+		m_queuePanelX[1] = 0;
 		for (Int s = 0; s < MAX_SLOTS; ++s)
 		{
 			m_playerOverlayExt[s].isPresent = false;
@@ -7956,7 +7958,6 @@ void InGameUI::drawPlayerInfoList()
 
 			overlayLog("DRAW_Q: entry valid1v1=%d\n", (Int)m_isValid1v1);
 
-			Int screenW = TheDisplay->getWidth();
 			Int screenH = TheDisplay->getHeight();
 			Int iconSize = Int(24 * scale);
 			Int iconSpacing = Int(3 * scale);
@@ -7971,14 +7972,8 @@ void InGameUI::drawPlayerInfoList()
 				overlayLog("DRAW_Q: player slot=%d ovIdx=%d queueSize=%zu\n", slot, ovIdx, q.size());
 				if (q.empty()) continue;
 
-				// Position: P1 left of scoreboard, P2 right of scoreboard (above command panel)
-				// Layout: max 3 columns per row, filling top→bottom, pinned to screen bottom
-				// Oldest items at top (always visible); newest push downward, may fall off viewport
-				Int panelX;
-				if (ovIdx == 0)
-					panelX = Int(screenW * 0.17f);  // between minimap and scoreboard
-				else
-					panelX = Int(screenW * 0.75f);  // between scoreboard and command panel
+				// Use runtime-snapped panel X (between minimap & scoreboard, or scoreboard & right HUD)
+				Int panelX = m_queuePanelX[ovIdx];
 
 				static const Int MAX_COLS = 3;
 				static const Int MAX_VISIBLE_ROWS = 3;
@@ -8239,12 +8234,8 @@ void InGameUI::drawPlayerInfoList()
 				const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
 				if (q.empty()) continue;
 
-				// Must match drawUnitQueuesImpl layout (bottom-pinned, 3 rows, oldest at top)
-				Int panelX;
-				if (ovIdx == 0)
-					panelX = Int(screenW * 0.17f);
-				else
-					panelX = Int(screenW * 0.75f);
+				// Use runtime-snapped panel X (matches drawUnitQueuesImpl)
+				Int panelX = m_queuePanelX[ovIdx];
 
 				static const Int MAX_COLS = 3;
 				static const Int MAX_VISIBLE_ROWS = 3;
@@ -8285,6 +8276,7 @@ void InGameUI::drawPlayerInfoList()
 				return;
 
 			// Reset shadow queues on new game/replay start (frame 2 is the first real frame)
+			// Also snapshot UI element positions for accurate queue placement
 			if (TheGameLogic->getFrame() == 2)
 			{
 				for (Int slot = 0; slot < MAX_SLOTS; ++slot)
@@ -8292,6 +8284,50 @@ void InGameUI::drawPlayerInfoList()
 					m_playerOverlayExt[slot].queue.clear();
 					m_playerOverlayExt[slot].isPresent = false;
 				}
+
+				// Snapshot radar (minimap) right edge and right HUD left edge
+				Int radarRight = 0;
+				Int rightHUDLeft = TheDisplay->getWidth();
+				if (TheWindowManager && TheNameKeyGenerator)
+				{
+					// Minimap / radar window
+					GameWindow* radarWin = TheWindowManager->winGetWindowFromId(nullptr,
+						TheNameKeyGenerator->nameToKey("ControlBar.wnd:Radar"));
+					if (radarWin)
+					{
+						IRegion2D radarRegion;
+						radarWin->winGetRegion(&radarRegion);
+						radarRight = radarRegion.hi.x;
+						overlayLog("LAYOUT: radar region lo=(%d,%d) hi=(%d,%d)\n",
+							radarRegion.lo.x, radarRegion.lo.y, radarRegion.hi.x, radarRegion.hi.y);
+					}
+
+					// Right HUD / command panel (faction logo + power bar)
+					GameWindow* rightHUD = TheWindowManager->winGetWindowFromId(nullptr,
+						TheNameKeyGenerator->nameToKey("ControlBar.wnd:RightHUD"));
+					if (rightHUD)
+					{
+						IRegion2D hudRegion;
+						rightHUD->winGetRegion(&hudRegion);
+						rightHUDLeft = hudRegion.lo.x;
+						overlayLog("LAYOUT: rightHUD region lo=(%d,%d) hi=(%d,%d)\n",
+							hudRegion.lo.x, hudRegion.lo.y, hudRegion.hi.x, hudRegion.hi.y);
+					}
+				}
+
+				// Store for use in draw: P1 between radar and scoreboard, P2 between scoreboard and right HUD
+				// Fallback: use screen-relative positions if windows not found
+				if (radarRight > 0)
+					m_queuePanelX[0] = radarRight + 4;  // small gap after minimap
+				else
+					m_queuePanelX[0] = Int(TheDisplay->getWidth() * 0.14f);
+
+				if (rightHUDLeft < TheDisplay->getWidth())
+					m_queuePanelX[1] = rightHUDLeft - 85; // queue width (3*27px) before right HUD
+				else
+					m_queuePanelX[1] = Int(TheDisplay->getWidth() * 0.76f);
+				overlayLog("LAYOUT: queue panel X: P1=%d P2=%d screenW=%d\n",
+					m_queuePanelX[0], m_queuePanelX[1], TheDisplay->getWidth());
 			}
 
 			if (!localPlayer->isPlayerObserver() && !localPlayer->isPlayerDead())

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -108,6 +108,10 @@ extern NetworkInterface * TheNetwork;
 // ProductionUpdate linked list can be corrupt in replay mode; these wrappers catch access violations.
 #pragma warning(push)
 #pragma warning(disable: 4611) // interaction between _try and C++ object destruction
+static UnsignedInt safeGetProductionCount(ProductionUpdateInterface* prod) {
+	__try { return prod->getProductionCount(); }
+	__except(EXCEPTION_EXECUTE_HANDLER) { return 0; }
+}
 static const ProductionEntry* safeFirstProduction(ProductionUpdateInterface* prod) {
 	__try { return prod->firstProduction(); }
 	__except(EXCEPTION_EXECUTE_HANDLER) { return nullptr; }
@@ -7434,7 +7438,7 @@ void InGameUI::drawPlayerInfoList()
 					// TheSuperHackers @test step 3: try production module access
 					ProductionUpdateInterface* prod = (ProductionUpdateInterface*)obj->findUpdateModule(
 						TheNameKeyGenerator->nameToKey("ProductionUpdate"));
-					if (!prod || prod->getProductionCount() == 0) return;
+					if (!prod || safeGetProductionCount(prod) == 0) return;
 
 										// TheSuperHackers @test step 4: slot-finding loop
 										Int slot = -1;
@@ -7622,9 +7626,25 @@ void InGameUI::drawPlayerInfoList()
 
 																														// Find an object with this special power module
 																														if (TheRecorder && TheRecorder->isPlaybackMode())
-																															ppi.hasModule = true; // replay: show all faction powers
+																														{
+																															// In replay, check if player has the required science for this power
+																															// This way only purchased/chosen powers are shown
+																															const SpecialPowerTemplate* sp = btn->getSpecialPowerTemplate();
+																															if (sp && sp->getRequiredScience() != SCIENCE_INVALID) {
+																																ppi.hasModule = p->hasScience(sp->getRequiredScience());
+																															} else {
+																																ppi.hasModule = true; // no science gate, show it
+																															}
+																															if (ppi.hasModule) {
+																																// Also try to get the module state (readyFrame)
+																																p->iterateObjects(findPowerModule, &ppi);
+																															}
+																														}
 																														else
+																														{
+																															// Skirmish: find modules normally
 																															p->iterateObjects(findPowerModule, &ppi);
+																														}
 
 					++numPowers;
 				}
@@ -7714,8 +7734,8 @@ void InGameUI::drawPlayerInfoList()
 				for (Int pi = 0; pi < m_playerOverlayExt[slot].powerCount; ++pi)
 				{
 					const PlayerPowerInfo& ppi = m_playerOverlayExt[slot].powers[pi];
-					if (!ppi.button) continue;
-					if (!ppi.hasModule) continue;
+					if (!ppi.button) { curY += ringSize + ringSpacing; continue; }
+					if (!ppi.hasModule) { curY += ringSize + ringSpacing; continue; }
 
 					Bool isReady = ppi.hasModule && currentFrame >= ppi.readyFrame;
 					Bool isFlashing = ppi.lastUsedFrame > 0 &&

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7550,6 +7550,7 @@ void InGameUI::drawPlayerInfoList()
 					if (ppi.button->getSpecialPowerTemplate() == spTemplate)
 					{
 						ppi.lastUsedFrame = currentFrame;
+						ppi.cooldownEndFrame = currentFrame + spTemplate->getReloadTime();
 						m_playerOverlayExt[slot].powerUsePos[pi].x = (Int)location.x;
 						m_playerOverlayExt[slot].powerUsePos[pi].y = (Int)location.y;
 						return;
@@ -7617,34 +7618,53 @@ void InGameUI::drawPlayerInfoList()
 					const CommandButton* btn = cmdSet->getCommandButton(i);
 					if (!btn || !btn->getSpecialPowerTemplate()) continue;
 
+					const SpecialPowerTemplate* sp = btn->getSpecialPowerTemplate();
+
+					// Skip non-shortcut powers (super weapons like Particle Cannon, Nuke, SCUD Storm
+					// have ShortcutPower=No in INI — they belong to the superweapon panel, not general powers)
+					if (!sp->isShortcutPower()) continue;
+
 					PlayerPowerInfo& ppi = m_playerOverlayExt[slot].powers[numPowers];
 					ppi.button = btn;
 					ppi.hasModule = false;
 					ppi.readyFrame = 0;
-																														if (ppi.lastUsedFrame > 0 && (currentFrame - ppi.lastUsedFrame) >= flashWindow)
-																															ppi.lastUsedFrame = 0;
+					ppi.cooldownEndFrame = 0;
+					if (ppi.lastUsedFrame > 0 && (currentFrame - ppi.lastUsedFrame) >= flashWindow)
+						ppi.lastUsedFrame = 0;
 
-																														// Find an object with this special power module
-																														if (TheRecorder && TheRecorder->isPlaybackMode())
-																														{
-																															// In replay, check if player has the required science for this power
-																															// This way only purchased/chosen powers are shown
-																															const SpecialPowerTemplate* sp = btn->getSpecialPowerTemplate();
-																															if (sp && sp->getRequiredScience() != SCIENCE_INVALID) {
-																																ppi.hasModule = p->hasScience(sp->getRequiredScience());
-																															} else {
-																																ppi.hasModule = true; // no science gate, show it
-																															}
-																															if (ppi.hasModule) {
-																																// Also try to get the module state (readyFrame)
-																																p->iterateObjects(findPowerModule, &ppi);
-																															}
-																														}
-																														else
-																														{
-																															// Skirmish: find modules normally
-																															p->iterateObjects(findPowerModule, &ppi);
-																														}
+					// Find an object with this special power module
+					if (TheRecorder && TheRecorder->isPlaybackMode())
+					{
+						// In replay: science check as proxy, then try iterateObjects for accuracy
+						if (sp->getRequiredScience() != SCIENCE_INVALID)
+							ppi.hasModule = p->hasScience(sp->getRequiredScience());
+						else
+							ppi.hasModule = true;
+
+						if (ppi.hasModule)
+						{
+							PlayerPowerInfo backup = ppi;
+							backup.hasModule = false;
+							p->iterateObjects(findPowerModule, &backup);
+							if (backup.hasModule)
+							{
+								// Module found on live object — accurate state
+								ppi.hasModule = true;
+								ppi.readyFrame = backup.readyFrame;
+							}
+							else
+							{
+								// Module not found — science known but building gone
+								ppi.hasModule = false;
+								ppi.readyFrame = 0;
+							}
+						}
+					}
+					else
+					{
+						// Skirmish: find modules normally
+						p->iterateObjects(findPowerModule, &ppi);
+					}
 
 					++numPowers;
 				}
@@ -7758,7 +7778,13 @@ void InGameUI::drawPlayerInfoList()
 					// Cooldown indicator (orange fill from bottom)
 					if (!isReady && ppi.hasModule)
 					{
-						Real progress = 1.0f - ((Real)(ppi.readyFrame - currentFrame) / (Real)LOGICFRAMES_PER_SECOND / 60.0f);
+						// Use actual reload time from the SpecialPowerTemplate
+						UnsignedInt reloadFrames = LOGICFRAMES_PER_SECOND * 60; // fallback 60s
+						const SpecialPowerTemplate* sp = ppi.button->getSpecialPowerTemplate();
+						if (sp && sp->getReloadTime() > 0)
+							reloadFrames = sp->getReloadTime();
+
+						Real progress = 1.0f - ((Real)(ppi.readyFrame - currentFrame) / (Real)reloadFrames);
 						if (progress < 0) progress = 0;
 						if (progress > 1) progress = 1;
 
@@ -7784,21 +7810,14 @@ void InGameUI::drawPlayerInfoList()
 							panelX + ringSize - 2, curY, panelX + ringSize, curY + ringSize);
 					}
 
-					// Flash effect on recently used
+					// Flash effect on recently used — green overlay over entire icon
 					if (isFlashing)
 					{
-						Real flashIntensity = 0.5f + 0.5f * sin((Real)(currentFrame) * 0.3f);
-						UnsignedInt flashR = (UnsignedInt)(255 * flashIntensity);
-						UnsignedInt flashG = (UnsignedInt)(128 * flashIntensity);
-						Color flashColor = TheWindowManager->winMakeColor(flashR, flashG, 0, 220);
+						Real flashIntensity = 0.3f + 0.4f * sin((Real)(currentFrame) * 0.3f);
+						UnsignedInt flashA = (UnsignedInt)(180 * flashIntensity);
+						Color flashColor = TheWindowManager->winMakeColor(0, 255, 0, flashA);
 						TheWindowManager->winFillRect(flashColor, 1,
-							panelX - 1, curY - 1, panelX + ringSize + 1, curY);
-						TheWindowManager->winFillRect(flashColor, 1,
-							panelX - 1, curY + ringSize, panelX + ringSize + 1, curY + ringSize + 1);
-						TheWindowManager->winFillRect(flashColor, 1,
-							panelX - 1, curY - 1, panelX, curY + ringSize + 1);
-						TheWindowManager->winFillRect(flashColor, 1,
-							panelX + ringSize, curY - 1, panelX + ringSize + 1, curY + ringSize + 1);
+							panelX, curY, panelX + ringSize, curY + ringSize);
 					}
 
 					curY += ringSize + ringSpacing;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7973,7 +7973,7 @@ void InGameUI::drawPlayerInfoList()
 
 				// Position: P1 left of scoreboard, P2 right of scoreboard (above command panel)
 				// Layout: max 3 columns per row, filling top→bottom, pinned to screen bottom
-				// Only the last 3 rows are visible; older rows scroll off below viewport
+				// Oldest items at top (always visible); newest push downward, may fall off viewport
 				Int panelX;
 				if (ovIdx == 0)
 					panelX = Int(screenW * 0.17f);  // between minimap and scoreboard
@@ -7983,23 +7983,18 @@ void InGameUI::drawPlayerInfoList()
 				static const Int MAX_COLS = 3;
 				static const Int MAX_VISIBLE_ROWS = 3;
 				Int step = iconSize + iconSpacing;
-				Int bottomMargin = Int(20 * scale);  // tight against bottom edge
-				Int bottomY = screenH - bottomMargin;
+				Int bottomY = screenH - Int(40 * scale);  // above bottom UI
 
-				Int totalRows = (Int)((q.size() + MAX_COLS - 1) / MAX_COLS);
-				Int visibleRows = (totalRows < MAX_VISIBLE_ROWS) ? totalRows : MAX_VISIBLE_ROWS;
-				Int skipRows = totalRows - visibleRows;  // rows above viewport (older)
-
+				// Show the OLDEST items first (row 0 at top of visible area)
 				for (size_t ei = 0; ei < q.size(); ++ei)
 				{
 					Int row = (Int)(ei / MAX_COLS);
-					Int visibleRow = row - skipRows;
-					if (visibleRow < 0) continue;  // above viewport → skip
+					if (row >= MAX_VISIBLE_ROWS) continue;  // below viewport → skip
 
 					Int col = (Int)(ei % MAX_COLS);
 					Int ix = panelX + col * step;
-					// visibleRow 0 = top of visible area, visibleRow 2 = bottom (against screen edge)
-					Int iy = bottomY - (MAX_VISIBLE_ROWS - visibleRow) * step;
+					// row 0 = top visible row, row 2 = bottom (against screen edge)
+					Int iy = bottomY - (MAX_VISIBLE_ROWS - row) * step;
 
 					// Try drawing the button image first
 					if (q[ei].tmpl && q[ei].tmpl->getButtonImage())
@@ -8244,7 +8239,7 @@ void InGameUI::drawPlayerInfoList()
 				const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
 				if (q.empty()) continue;
 
-				// Must match drawUnitQueuesImpl layout (bottom-pinned, 3 rows visible, top→bottom fill)
+				// Must match drawUnitQueuesImpl layout (bottom-pinned, 3 rows, oldest at top)
 				Int panelX;
 				if (ovIdx == 0)
 					panelX = Int(screenW * 0.17f);
@@ -8254,22 +8249,16 @@ void InGameUI::drawPlayerInfoList()
 				static const Int MAX_COLS = 3;
 				static const Int MAX_VISIBLE_ROWS = 3;
 				Int step = iconSize + iconSpacing;
-				Int bottomMargin = Int(20 * scale);
-				Int bottomY = screenH - bottomMargin;
-
-				Int totalRows = (Int)((q.size() + MAX_COLS - 1) / MAX_COLS);
-				Int visibleRows = (totalRows < MAX_VISIBLE_ROWS) ? totalRows : MAX_VISIBLE_ROWS;
-				Int skipRows = totalRows - visibleRows;
+				Int bottomY = screenH - Int(40 * scale);
 
 				for (size_t ei = 0; ei < q.size(); ++ei)
 				{
 					Int row = (Int)(ei / MAX_COLS);
-					Int visibleRow = row - skipRows;
-					if (visibleRow < 0) continue;
+					if (row >= MAX_VISIBLE_ROWS) continue;
 
 					Int col = (Int)(ei % MAX_COLS);
 					Int ix = panelX + col * step;
-					Int iy = bottomY - (MAX_VISIBLE_ROWS - visibleRow) * step;
+					Int iy = bottomY - (MAX_VISIBLE_ROWS - row) * step;
 
 					if (mx >= ix && mx <= ix + iconSize &&
 						my >= iy && my <= iy + iconSize)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7562,7 +7562,7 @@ void InGameUI::drawPlayerInfoList()
 				overlayLog("COLLECT: %s slot=%d firstProduction=nullptr (prodCount=%u) — replay mode, linked list not restored\n",
 					name.str(), slot, prodCount);
 				// Fallback: push a single placeholder entry with just the building info
-				InGameUI::QueueEntry qe;
+				InGameUI::QueueEntry qe = {};
 				qe.tmpl = tmpl;  // use building template so we get the building icon
 				qe.percentComplete = 0.0f;
 				qe.buildingPos = buildingPos;
@@ -7577,7 +7577,7 @@ void InGameUI::drawPlayerInfoList()
 				overlayLog("COLLECT: %s entry type=%d\n", name.str(), (Int)pt);
 				if (pt == PRODUCTION_UNIT)
 				{
-					InGameUI::QueueEntry qe;
+					InGameUI::QueueEntry qe = {};
 					qe.tmpl = safeGetProductionObject(entry);
 					qe.percentComplete = safeGetPercentComplete(entry);
 					qe.buildingPos = buildingPos;
@@ -7591,7 +7591,7 @@ void InGameUI::drawPlayerInfoList()
 				}
 				else if (pt == PRODUCTION_UPGRADE)
 				{
-					InGameUI::QueueEntry qe;
+					InGameUI::QueueEntry qe = {};
 					qe.upgradeTmpl = safeGetProductionUpgrade(entry);
 					qe.percentComplete = safeGetPercentComplete(entry);
 					qe.buildingPos = buildingPos;
@@ -7728,7 +7728,7 @@ void InGameUI::drawPlayerInfoList()
 			if (btmpl) buildingName = btmpl->getName();
 
 			// Push into the player's queue
-			QueueEntry qe;
+			QueueEntry qe = {};
 			qe.tmpl = unitType;
 			qe.percentComplete = percentComplete;
 			qe.buildingPos = buildingPos;
@@ -7836,7 +7836,7 @@ void InGameUI::drawPlayerInfoList()
 			const ThingTemplate* btmpl = producer->getTemplate();
 			if (btmpl) buildingName = btmpl->getName();
 
-			QueueEntry qe;
+			QueueEntry qe = {};
 			qe.upgradeTmpl = upgradeType;
 			qe.percentComplete = percentComplete;
 			qe.buildingPos = buildingPos;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7480,8 +7480,14 @@ void InGameUI::drawPlayerInfoList()
 			SpecialPowerModuleInterface* mod = obj->getSpecialPowerModule(info->button->getSpecialPowerTemplate());
 			if (mod)
 			{
-				info->hasModule = true;
-				info->readyFrame = mod->getReadyFrame();
+				// Only count this module if the building is fully built.
+				// Buildings under construction return 0..100; CONSTRUCTION_COMPLETE = -1 means done.
+				Real constPct = obj->getConstructionPercent();
+				if (constPct == CONSTRUCTION_COMPLETE || constPct >= 100.0f)
+				{
+					info->hasModule = true;
+					info->readyFrame = mod->getReadyFrame();
+				}
 			}
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -41,6 +41,7 @@
 #include "Common/PerfTimer.h"
 #include "Common/Player.h"
 #include "Common/PlayerList.h"
+#include "Common/PlayerTemplate.h"
 #include "Common/Radar.h"
 #include "Common/Team.h"
 #include "Common/ThingFactory.h"
@@ -48,7 +49,6 @@
 #include "Common/BuildAssistant.h"
 #include "Common/Recorder.h"
 #include "Common/SpecialPower.h"
-
 #include "GameClient/Anim2D.h"
 #include "GameClient/ControlBar.h"
 #include "GameClient/DisplayStringManager.h"
@@ -103,6 +103,28 @@ extern NetworkInterface * TheNetwork;
 #endif
 #include "ValveNetworkingSockets/steam/isteamnetworkingsockets.h"
 
+
+// TheSuperHackers @feature SEH-safe production entry accessors for replay mode
+// ProductionUpdate linked list can be corrupt in replay mode; these wrappers catch access violations.
+#pragma warning(push)
+#pragma warning(disable: 4611) // interaction between _try and C++ object destruction
+static const ProductionEntry* safeFirstProduction(ProductionUpdateInterface* prod) {
+	__try { return prod->firstProduction(); }
+	__except(EXCEPTION_EXECUTE_HANDLER) { return nullptr; }
+}
+static const ThingTemplate* safeGetProductionObject(const ProductionEntry* entry) {
+	__try { return entry->getProductionObject(); }
+	__except(EXCEPTION_EXECUTE_HANDLER) { return nullptr; }
+}
+static Real safeGetPercentComplete(const ProductionEntry* entry) {
+	__try { return entry->getPercentComplete(); }
+	__except(EXCEPTION_EXECUTE_HANDLER) { return 0.0f; }
+}
+static const ProductionEntry* safeNextProduction(ProductionUpdateInterface* prod, const ProductionEntry* entry) {
+	__try { return prod->nextProduction(const_cast<ProductionEntry*>(entry)); }
+	__except(EXCEPTION_EXECUTE_HANDLER) { return nullptr; }
+}
+#pragma warning(pop)
 
 // ------------------------------------------------------------------------------------------------
 static const RGBColor IllegalBuildColor = { 1.0, 0.0, 0.0 };
@@ -1281,20 +1303,37 @@ InGameUI::InGameUI()
 	m_moveRMBScrollAnchor = FALSE;
 	m_displayedMaxWarning = FALSE;
 
-	m_idleWorkerWin = nullptr;
-	m_currentIdleWorkerDisplay = -1;
+		m_idleWorkerWin = nullptr;
+		m_currentIdleWorkerDisplay = -1;
 
-	m_waypointMode = false;
-	m_forceAttackMode = false;
-	m_forceMoveToMode = false;
-	m_attackMoveToMode = false;
-	m_preferSelection = false;
+		m_waypointMode = false;
+		m_forceAttackMode = false;
+		m_forceMoveToMode = false;
+		m_attackMoveToMode = false;
+		m_preferSelection = false;
 
-	m_curRcType = RADIUSCURSOR_NONE;
+		m_curRcType = RADIUSCURSOR_NONE;
 
-	m_soloNexusSelectedDrawableID = INVALID_DRAWABLE_ID;
+		m_soloNexusSelectedDrawableID = INVALID_DRAWABLE_ID;
 
-}
+		// TheSuperHackers @feature 14/07/2026 Init overlay ext data
+		m_isValid1v1 = false;
+		m_overlayPlayerSlots[0] = -1;
+		m_overlayPlayerSlots[1] = -1;
+		for (Int s = 0; s < MAX_SLOTS; ++s)
+		{
+			m_playerOverlayExt[s].isPresent = false;
+			m_playerOverlayExt[s].powerCount = 0;
+			for (Int p = 0; p < MAX_POWERS_PER_PLAYER; ++p)
+			{
+				m_playerOverlayExt[s].powers[p].button = nullptr;
+				m_playerOverlayExt[s].powers[p].lastUsedFrame = 0;
+				m_playerOverlayExt[s].powers[p].hasModule = false;
+				m_playerOverlayExt[s].powerUsePos[p].x = 0;
+				m_playerOverlayExt[s].powerUsePos[p].y = 0;
+			}
+		}
+	}
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
@@ -6523,10 +6562,15 @@ void InGameUI::drawObserverStats(Int & x, Int & y)
 	if (!localPlayer || (TheGameLogic && TheGameLogic->getFrame() <= 1))
 		return;
 
-	if (!localPlayer->isPlayerObserver() && !localPlayer->isPlayerDead())
-		return;
+		if (!localPlayer->isPlayerObserver() && !localPlayer->isPlayerDead())
+			return;
 
-	if (!isAtHudAnchorPos(m_observerStatsPosition) || m_observerStatsHidden)
+		// TheSuperHackers @feature 14/07/2026 Gather overlay extension data for unit queues and powers
+		// Delay 60 frames (1s) to let replay mode fully initialize game state
+		if (TheGameLogic && TheGameLogic->getFrame() >= 60)
+			gatherOverlayExtData();
+
+		if (!isAtHudAnchorPos(m_observerStatsPosition) || m_observerStatsHidden)
 		return;
 
 	// couldn't allocate memory, early out
@@ -6751,7 +6795,18 @@ void InGameUI::drawObserverStats(Int & x, Int & y)
     Int lineHeight = (m_observerStatsLineStep > 0) ? m_observerStatsLineStep : Int(16 * scale);
     Int rowSpacing = Int(2 * scale);
 
-    totalHeight = (lineHeight + rowSpacing) * (1 + Int(actualNumPlayers));
+	totalHeight = (lineHeight + rowSpacing) * (1 + Int(actualNumPlayers));
+
+	// TheSuperHackers @feature 14/07/2026 Draw unit queues and power cooldowns
+	// Compute positions independently of stats table (may be empty in replay mode)
+	{	Int queueBaseY = screenH - Int(80 * scale);
+		if (queueBaseY < 0) queueBaseY = 0;
+		Int queueLineH = Int(18 * scale);
+		if (queueLineH < 1) queueLineH = 1;
+		drawUnitQueues(Int(10 * scale), queueBaseY, queueLineH, scale);
+		drawPowerCooldowns(Int(10 * scale), queueBaseY, queueLineH, scale);
+		drawPowerFlashes();
+	}
 
 	if (actualNumPlayers == 0)
 		return;
@@ -7354,6 +7409,453 @@ void InGameUI::drawPlayerInfoList()
 
 		m_playerInfoList.values[PlayerInfoList::ValueType_Name][row]->draw(labelX, drawY, rowColors[row], m_playerInfoListDropColor);
 
-		drawY += lineH;
-	}
-}
+				drawY += lineH;
+			}
+		}
+
+		// =================================================================================================
+		// TheSuperHackers @feature 14/07/2026 Spectator overlay: unit queues and power cooldowns
+		// =================================================================================================
+
+				void InGameUI::collectQueueEntries(Object* obj, void* userData)
+				{
+					if (!obj) return;
+					const ThingTemplate* tmpl = obj->getTemplate();
+					if (!tmpl) return;
+
+					// TheSuperHackers @test step 2: only check building type
+					InGameUI::BuildingType bt = InGameUI::BUILDING_COUNT;
+					AsciiString name = tmpl->getName();
+					if (name.endsWith("WarFactory"))       bt = InGameUI::BUILDING_WAR_FACTORY;
+					else if (name.endsWith("Barracks"))     bt = InGameUI::BUILDING_BARRACKS;
+					else if (name.endsWith("AirField"))     bt = InGameUI::BUILDING_AIRFIELD;
+					if (bt == InGameUI::BUILDING_COUNT) return;
+
+					// TheSuperHackers @test step 3: try production module access
+					ProductionUpdateInterface* prod = (ProductionUpdateInterface*)obj->findUpdateModule(
+						TheNameKeyGenerator->nameToKey("ProductionUpdate"));
+					if (!prod || prod->getProductionCount() == 0) return;
+
+										// TheSuperHackers @test step 4: slot-finding loop
+										Int slot = -1;
+										for (Int s = 0; s < MAX_SLOTS; ++s)
+					{
+						AsciiString nsk;
+						nsk.format("player%d", s);
+						Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+						if (pp && obj->getControllingPlayer() == pp) { slot = s; break; }
+					}
+					if (slot < 0) return;
+
+					// TheSuperHackers @fix: production entry traversal can crash in replay mode (corrupted linked list).
+					// Use safe wrapper functions that handle the crash gracefully.
+					InGameUI* ui = (InGameUI*)userData;
+					InGameUI::PlayerOverlayExt& ext = ui->m_playerOverlayExt[slot];
+					const ProductionEntry* entry = safeFirstProduction(prod);
+					Int count = 0;
+					while (entry && count < InGameUI::MAX_VISIBLE_QUEUE)
+					{
+						if (entry->getProductionType() == PRODUCTION_UNIT)
+						{
+							InGameUI::QueueEntry qe;
+							qe.tmpl = safeGetProductionObject(entry);
+							qe.percentComplete = safeGetPercentComplete(entry);
+							ext.queue[bt].push_back(qe);
+							++count;
+						}
+						entry = safeNextProduction(prod, entry);
+					}
+			}
+	
+			// Helper: find special power module for one power slot
+		void InGameUI::findPowerModule(Object* obj, void* userData)
+		{
+			if (!obj) return;
+			InGameUI::PlayerPowerInfo* info = (InGameUI::PlayerPowerInfo*)userData;
+			if (info->hasModule) return;
+			SpecialPowerModuleInterface* mod = obj->getSpecialPowerModule(info->button->getSpecialPowerTemplate());
+			if (mod)
+			{
+				info->hasModule = true;
+				info->readyFrame = mod->getReadyFrame();
+			}
+		}
+
+		void InGameUI::resolveOverlayPlayers()
+		{
+			m_isValid1v1 = false;
+			m_overlayPlayerSlots[0] = -1;
+			m_overlayPlayerSlots[1] = -1;
+
+			if (!ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			Int found[2] = { -1, -1 };
+			Int count = 0;
+
+			// Iterate all slots, look up each player by name key.
+			// Works in skirmish AND replay mode (no dependency on TheGameInfo, which is null in replay)
+			for (Int slotIndex = 0; slotIndex < MAX_SLOTS; ++slotIndex)
+			{
+				AsciiString nameKeyStr;
+				nameKeyStr.format("player%d", slotIndex);
+				Player* p = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nameKeyStr));
+				if (!p || !p->isPlayerActive() || p->isPlayerObserver())
+					continue;
+
+				if (count < 2)
+					found[count] = slotIndex;
+				++count;
+			}
+
+			if (count == 2)
+			{
+				m_isValid1v1 = true;
+				m_overlayPlayerSlots[0] = found[0];
+				m_overlayPlayerSlots[1] = found[1];
+			}
+		}
+
+		// TheSuperHackers @feature 14/07/2026 Power use target tracking
+		void InGameUI::onSpecialPowerTriggered(Player* player, const SpecialPowerTemplate* spTemplate, const Coord3D& location)
+		{
+			if (!player || !spTemplate || !ThePlayerList || !TheNameKeyGenerator || !TheGameLogic)
+				return;
+
+			if (!m_isValid1v1)
+				return;
+
+			UnsignedInt currentFrame = TheGameLogic->getFrame();
+
+			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
+			{
+				Int slot = m_overlayPlayerSlots[ovIdx];
+				if (slot < 0 || slot >= MAX_SLOTS) continue;
+
+				// Verify this player is one of our tracked 1v1 players
+				AsciiString nameKeyStr;
+				nameKeyStr.format("player%d", slot);
+				Player* p = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nameKeyStr));
+				if (p != player) continue;
+
+				// Find the matching power slot and store the target location
+				for (Int pi = 0; pi < m_playerOverlayExt[slot].powerCount; ++pi)
+				{
+					PlayerPowerInfo& ppi = m_playerOverlayExt[slot].powers[pi];
+					if (!ppi.button) continue;
+					if (ppi.button->getSpecialPowerTemplate() == spTemplate)
+					{
+						ppi.lastUsedFrame = currentFrame;
+						m_playerOverlayExt[slot].powerUsePos[pi].x = (Int)location.x;
+						m_playerOverlayExt[slot].powerUsePos[pi].y = (Int)location.y;
+						return;
+					}
+				}
+			}
+		}
+
+		void InGameUI::gatherOverlayExtData()
+		{
+			if (!TheGameLogic || !ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			UnsignedInt currentFrame = TheGameLogic ? TheGameLogic->getFrame() : 0;
+			UnsignedInt flashWindow = (UnsignedInt)(LOGICFRAMES_PER_SECOND * 3); // 3 seconds
+
+			// Resolve the two 1v1 player slots
+			resolveOverlayPlayers();
+
+			// Clear all overlay ext slots first
+			for (Int slot = 0; slot < MAX_SLOTS; ++slot)
+				m_playerOverlayExt[slot].isPresent = false;
+
+			if (!m_isValid1v1)
+				return;
+
+			// Only process the two mapped 1v1 players
+			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
+			{
+				Int slot = m_overlayPlayerSlots[ovIdx];
+				if (slot < 0 || slot >= MAX_SLOTS)
+					continue;
+
+				m_playerOverlayExt[slot].isPresent = true;
+
+				AsciiString nameKeyStr;
+				nameKeyStr.format("player%d", slot);
+				NameKeyType key = TheNameKeyGenerator->nameToKey(nameKeyStr);
+				Player* p = ThePlayerList->findPlayerWithNameKey(key);
+				if (!p)
+				{
+					m_playerOverlayExt[slot].isPresent = false;
+					continue;
+				}
+
+				// ---- Unit queues ----
+				for (Int bt = 0; bt < BUILDING_COUNT; ++bt)
+															m_playerOverlayExt[slot].queue[bt].clear();
+
+														p->iterateObjects(collectQueueEntries, this);
+
+														// ---- General power cooldowns ----
+				const PlayerTemplate* pt = p->getPlayerTemplate();
+				if (!pt) continue;
+
+				Int numPowers = 0;
+				AsciiString cmdSetName = pt->getSpecialPowerShortcutCommandSet();
+				if (cmdSetName.isEmpty()) continue;
+
+				const CommandSet* cmdSet = TheControlBar ? TheControlBar->findCommandSet(cmdSetName) : nullptr;
+				if (!cmdSet) continue;
+
+				for (Int i = 0; i < MAX_COMMANDS_PER_SET && numPowers < MAX_POWERS_PER_PLAYER; ++i)
+				{
+					const CommandButton* btn = cmdSet->getCommandButton(i);
+					if (!btn || !btn->getSpecialPowerTemplate()) continue;
+
+					PlayerPowerInfo& ppi = m_playerOverlayExt[slot].powers[numPowers];
+					ppi.button = btn;
+					ppi.hasModule = false;
+					ppi.readyFrame = 0;
+																														if (ppi.lastUsedFrame > 0 && (currentFrame - ppi.lastUsedFrame) >= flashWindow)
+																															ppi.lastUsedFrame = 0;
+
+																														// Find an object with this special power module
+																														if (TheRecorder && TheRecorder->isPlaybackMode())
+																															ppi.hasModule = true; // replay: show all faction powers
+																														else
+																															p->iterateObjects(findPowerModule, &ppi);
+
+					++numPowers;
+				}
+				m_playerOverlayExt[slot].powerCount = numPowers;
+
+				for (Int i = 0; i < numPowers; ++i)
+				{
+					if (m_playerOverlayExt[slot].powers[i].lastUsedFrame == 0)
+						m_playerOverlayExt[slot].powerUsePos[i].x = m_playerOverlayExt[slot].powerUsePos[i].y = 0;
+				}
+			}
+		}
+
+		void InGameUI::drawUnitQueues(Int baseX, Int baseY, Int lineH, Real scale)
+		{
+			if (!TheDisplay || !m_isValid1v1) return;
+
+			Int iconSize = Int(20 * scale);
+			Int iconSpacing = Int(2 * scale);
+			Int startX = baseX;
+
+			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
+			{
+				Int slot = m_overlayPlayerSlots[ovIdx];
+				if (slot < 0 || slot >= MAX_SLOTS) continue;
+				if (!m_playerOverlayExt[slot].isPresent) continue;
+
+				Int rowY = baseY + (ovIdx + 1) * lineH;
+				for (Int bt = 0; bt < BUILDING_COUNT; ++bt)
+				{
+					const std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue[bt];
+					if (q.empty()) continue;
+
+					Int iconX = startX;
+					for (size_t ei = 0; ei < q.size(); ++ei)
+					{
+						if (q[ei].tmpl && q[ei].tmpl->getButtonImage())
+						{
+							const Image* img = q[ei].tmpl->getButtonImage();
+							TheDisplay->drawImage(img, iconX, rowY, iconX + iconSize, rowY + iconSize);
+							// Draw progress bar at bottom of icon
+							Int progW = (Int)(iconSize * q[ei].percentComplete / 100.0f);
+							if (progW > 0)
+								TheWindowManager->winFillRect(
+									TheWindowManager->winMakeColor(0, 200, 0, 180), 1,
+									iconX, rowY + iconSize - 3, iconX + progW, rowY + iconSize);
+						}
+						iconX += iconSize + iconSpacing;
+						if (iconX > startX + 150) break;
+					}
+					rowY += iconSize + iconSpacing;
+				}
+			}
+		}
+
+		void InGameUI::drawPowerCooldowns(Int baseX, Int baseY, Int lineH, Real scale)
+		{
+			if (!TheGameLogic || !m_isValid1v1) return;
+
+			UnsignedInt currentFrame = TheGameLogic->getFrame();
+			Int ringSize = Int(44 * scale);
+			Int ringSpacing = Int(6 * scale);
+			UnsignedInt flashWindow = (UnsignedInt)(LOGICFRAMES_PER_SECOND * 3);
+
+			Int screenW = TheDisplay ? TheDisplay->getWidth() : 1920;
+			Int screenH = TheDisplay ? TheDisplay->getHeight() : 1080;
+
+			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
+			{
+				Int slot = m_overlayPlayerSlots[ovIdx];
+				if (slot < 0 || slot >= MAX_SLOTS) continue;
+				if (!m_playerOverlayExt[slot].isPresent) continue;
+				if (m_playerOverlayExt[slot].powerCount == 0) continue;
+
+				// Position: left edge (player 1) / right edge (player 2), vertically centered
+				Int panelX;
+				if (ovIdx == 0)
+					panelX = Int(12 * scale);
+				else
+					panelX = screenW - Int(12 * scale) - ringSize;
+
+				Int totalPanelH = m_playerOverlayExt[slot].powerCount * (ringSize + ringSpacing) - ringSpacing;
+				Int panelY = (screenH - totalPanelH) / 2;
+				if (panelY < 0) panelY = 0;
+
+				Int curY = panelY;
+				for (Int pi = 0; pi < m_playerOverlayExt[slot].powerCount; ++pi)
+				{
+					const PlayerPowerInfo& ppi = m_playerOverlayExt[slot].powers[pi];
+					if (!ppi.button) continue;
+					if (!ppi.hasModule) continue;
+
+					Bool isReady = ppi.hasModule && currentFrame >= ppi.readyFrame;
+					Bool isFlashing = ppi.lastUsedFrame > 0 &&
+						(currentFrame - ppi.lastUsedFrame) < flashWindow;
+
+					// Draw power button icon
+					const Image* btnImg = ppi.button->getButtonImage();
+					if (btnImg)
+					{
+						TheDisplay->drawImage(btnImg, panelX, curY, panelX + ringSize, curY + ringSize,
+							GameMakeColor(255, 255, 255, 200));
+					}
+					else
+					{
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(0, 0, 0, 180), 1,
+							panelX, curY, panelX + ringSize, curY + ringSize);
+					}
+
+					// Cooldown indicator (orange fill from bottom)
+					if (!isReady && ppi.hasModule)
+					{
+						Real progress = 1.0f - ((Real)(ppi.readyFrame - currentFrame) / (Real)LOGICFRAMES_PER_SECOND / 60.0f);
+						if (progress < 0) progress = 0;
+						if (progress > 1) progress = 1;
+
+						Int progH = (Int)(ringSize * progress);
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(255, 200, 0, 120), 1,
+							panelX, curY + ringSize - progH, panelX + ringSize, curY + ringSize);
+					}
+					else if (isReady)
+					{
+						// Green border = ready
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(0, 255, 0, 200), 1,
+							panelX, curY, panelX + ringSize, curY + 2);
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(0, 255, 0, 200), 1,
+							panelX, curY + ringSize - 2, panelX + ringSize, curY + ringSize);
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(0, 255, 0, 200), 1,
+							panelX, curY, panelX + 2, curY + ringSize);
+						TheWindowManager->winFillRect(
+							TheWindowManager->winMakeColor(0, 255, 0, 200), 1,
+							panelX + ringSize - 2, curY, panelX + ringSize, curY + ringSize);
+					}
+
+					// Flash effect on recently used
+					if (isFlashing)
+					{
+						Real flashIntensity = 0.5f + 0.5f * sin((Real)(currentFrame) * 0.3f);
+						UnsignedInt flashR = (UnsignedInt)(255 * flashIntensity);
+						UnsignedInt flashG = (UnsignedInt)(128 * flashIntensity);
+						Color flashColor = TheWindowManager->winMakeColor(flashR, flashG, 0, 220);
+						TheWindowManager->winFillRect(flashColor, 1,
+							panelX - 1, curY - 1, panelX + ringSize + 1, curY);
+						TheWindowManager->winFillRect(flashColor, 1,
+							panelX - 1, curY + ringSize, panelX + ringSize + 1, curY + ringSize + 1);
+						TheWindowManager->winFillRect(flashColor, 1,
+							panelX - 1, curY - 1, panelX, curY + ringSize + 1);
+						TheWindowManager->winFillRect(flashColor, 1,
+							panelX + ringSize, curY - 1, panelX + ringSize + 1, curY + ringSize + 1);
+					}
+
+					curY += ringSize + ringSpacing;
+				}
+			}
+		}
+
+		void InGameUI::drawPowerFlashes()
+		{
+			// Click-to-navigate: check if mouse clicked on a power icon
+			if (!TheDisplay || !TheMouse || !TheTacticalView || !m_isValid1v1)
+				return;
+			if (!TheGameLogic)
+				return;
+
+			const MouseIO* mouse = TheMouse->getMouseStatus();
+			if (!mouse)
+				return;
+
+			// Only handle on the frame the left button is first pressed down
+			if (mouse->leftState != MBS_Down)
+				return;
+
+			Int mx = mouse->pos.x;
+			Int my = mouse->pos.y;
+
+			Int screenW = TheDisplay->getWidth();
+			Int screenH = TheDisplay->getHeight();
+			Real scale = (Real)screenW / 1920.0f;
+			scale = (scale < 0.7f) ? 0.7f : (scale > 2.0f) ? 2.0f : scale;
+			Int ringSize = Int(44 * scale);
+			Int ringSpacing = Int(6 * scale);
+
+			for (Int ovIdx = 0; ovIdx < 2; ++ovIdx)
+			{
+				Int slot = m_overlayPlayerSlots[ovIdx];
+				if (slot < 0 || slot >= MAX_SLOTS) continue;
+				if (!m_playerOverlayExt[slot].isPresent) continue;
+				if (m_playerOverlayExt[slot].powerCount == 0) continue;
+
+				// Must match drawPowerCooldowns layout
+				Int panelX;
+				if (ovIdx == 0)
+					panelX = Int(12 * scale);
+				else
+					panelX = screenW - Int(12 * scale) - ringSize;
+
+				Int totalPanelH = m_playerOverlayExt[slot].powerCount * (ringSize + ringSpacing) - ringSpacing;
+				Int panelY = (screenH - totalPanelH) / 2;
+				if (panelY < 0) panelY = 0;
+
+				Int curY = panelY;
+				for (Int pi = 0; pi < m_playerOverlayExt[slot].powerCount; ++pi)
+				{
+					const PlayerPowerInfo& ppi = m_playerOverlayExt[slot].powers[pi];
+					if (!ppi.button) { curY += ringSize + ringSpacing; continue; }
+					if (!ppi.hasModule) { curY += ringSize + ringSpacing; continue; }
+
+					if (mx >= panelX && mx <= panelX + ringSize &&
+						my >= curY && my <= curY + ringSize)
+					{
+						// Clicked on this power icon — navigate to target location
+						if (m_playerOverlayExt[slot].powerUsePos[pi].x != 0 ||
+							m_playerOverlayExt[slot].powerUsePos[pi].y != 0)
+						{
+							Coord3D dest;
+							dest.x = (Real)m_playerOverlayExt[slot].powerUsePos[pi].x;
+							dest.y = (Real)m_playerOverlayExt[slot].powerUsePos[pi].y;
+							dest.z = 0.0f;
+							TheTacticalView->lookAt(&dest);
+						}
+						break;
+					}
+					curY += ringSize + ringSpacing;
+				}
+			}
+		}
+
+		// @todo notifyGeneralPromotion and notifySpecialPowerUsed are already implemented above
+		// (they are observer notification functions, not overlay data functions).

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -135,6 +135,10 @@ static ProductionType safeGetProductionType(const ProductionEntry* entry) {
 	__try { return entry->getProductionType(); }
 	__except(EXCEPTION_EXECUTE_HANDLER) { return PRODUCTION_INVALID; }
 }
+static const UpgradeTemplate* safeGetProductionUpgrade(const ProductionEntry* entry) {
+	__try { return entry->getProductionUpgrade(); }
+	__except(EXCEPTION_EXECUTE_HANDLER) { return nullptr; }
+}
 #pragma warning(pop)
 
 // TheSuperHackers @feature 15/07/2026 Debug logging for overlay diagnostics
@@ -7585,6 +7589,20 @@ void InGameUI::drawPlayerInfoList()
 						qe.tmpl ? qe.tmpl->getName().str() : "NULL",
 						qe.percentComplete);
 				}
+				else if (pt == PRODUCTION_UPGRADE)
+				{
+					InGameUI::QueueEntry qe;
+					qe.upgradeTmpl = safeGetProductionUpgrade(entry);
+					qe.percentComplete = safeGetPercentComplete(entry);
+					qe.buildingPos = buildingPos;
+					qe.buildingName = name;
+					ext.queue.push_back(qe);
+
+					overlayLog("Queue: slot=%d building=%s upgrade=%s pct=%.0f%%\n",
+						slot, name.str(),
+						qe.upgradeTmpl ? qe.upgradeTmpl->getUpgradeName().str() : "NULL",
+						qe.percentComplete);
+				}
 				entry = safeNextProduction(prod, entry);
 			}
 		}
@@ -7790,6 +7808,110 @@ void InGameUI::drawPlayerInfoList()
 			}
 		}
 
+		// TheSuperHackers @feature 17/07/2026 Shadow upgrade queue: called from ProductionUpdate::queueUpgrade hook.
+		void InGameUI::onUpgradeQueued(Player* player, const UpgradeTemplate* upgradeType, Object* producer, Real percentComplete)
+		{
+			if (!player || !upgradeType || !producer || !ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			if (!m_isValid1v1)
+				return;
+
+			Int slot = -1;
+			for (Int s = 0; s < MAX_SLOTS; ++s)
+			{
+				AsciiString nsk;
+				nsk.format("player%d", s);
+				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+				if (pp == player) { slot = s; break; }
+			}
+			if (slot < 0 || slot >= MAX_SLOTS) return;
+			if (!m_playerOverlayExt[slot].isPresent) return;
+
+			const Coord3D* pos = producer->getPosition();
+			Coord3D buildingPos = { 0, 0, 0 };
+			if (pos) buildingPos = *pos;
+
+			AsciiString buildingName;
+			const ThingTemplate* btmpl = producer->getTemplate();
+			if (btmpl) buildingName = btmpl->getName();
+
+			QueueEntry qe;
+			qe.upgradeTmpl = upgradeType;
+			qe.percentComplete = percentComplete;
+			qe.buildingPos = buildingPos;
+			qe.buildingName = buildingName;
+			qe.producer = producer;
+			m_playerOverlayExt[slot].queue.push_back(qe);
+
+			overlayLog("QUEUED: slot=%d building=%s upgrade=%s pct=%.0f%%\n",
+				slot, buildingName.str(),
+				upgradeType ? upgradeType->getUpgradeName().str() : "NULL",
+				percentComplete);
+		}
+
+		// TheSuperHackers @feature 17/07/2026 Called from ProductionUpdate::update hook (upgrade completion).
+		void InGameUI::onUpgradeCompleted(Player* player, const UpgradeTemplate* upgradeType, Object* producer)
+		{
+			if (!player || !upgradeType || !producer || !ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			Int slot = -1;
+			for (Int s = 0; s < MAX_SLOTS; ++s)
+			{
+				AsciiString nsk;
+				nsk.format("player%d", s);
+				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+				if (pp == player) { slot = s; break; }
+			}
+			if (slot < 0 || slot >= MAX_SLOTS) return;
+			if (!m_playerOverlayExt[slot].isPresent) return;
+
+			std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
+			for (size_t i = 0; i < q.size(); ++i)
+			{
+				if (q[i].upgradeTmpl == upgradeType && q[i].producer == producer)
+				{
+					overlayLog("COMPLETED: slot=%d building=%s upgrade=%s removed\n",
+						slot, q[i].buildingName.str(),
+						upgradeType->getUpgradeName().str());
+					q.erase(q.begin() + i);
+					return;
+				}
+			}
+		}
+
+		// TheSuperHackers @feature 17/07/2026 Called from ProductionUpdate::cancelUpgrade hook.
+		void InGameUI::onUpgradeCancelled(Player* player, const UpgradeTemplate* upgradeType, Object* producer)
+		{
+			if (!player || !upgradeType || !producer || !ThePlayerList || !TheNameKeyGenerator)
+				return;
+
+			Int slot = -1;
+			for (Int s = 0; s < MAX_SLOTS; ++s)
+			{
+				AsciiString nsk;
+				nsk.format("player%d", s);
+				Player* pp = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(nsk));
+				if (pp == player) { slot = s; break; }
+			}
+			if (slot < 0 || slot >= MAX_SLOTS) return;
+			if (!m_playerOverlayExt[slot].isPresent) return;
+
+			std::vector<QueueEntry>& q = m_playerOverlayExt[slot].queue;
+			for (size_t i = 0; i < q.size(); ++i)
+			{
+				if (q[i].upgradeTmpl == upgradeType && q[i].producer == producer)
+				{
+					overlayLog("CANCELLED: slot=%d building=%s upgrade=%s removed\n",
+						slot, q[i].buildingName.str(),
+						upgradeType->getUpgradeName().str());
+					q.erase(q.begin() + i);
+					return;
+				}
+			}
+		}
+
 		// TheSuperHackers @feature 15/07/2026 Called from ProductionUpdate::onDie hook.
 		// Removes ALL queued units for a destroyed/sold building (bypasses corrupt linked list in replay).
 		void InGameUI::onBuildingDestroyed(Object* producer)
@@ -7804,9 +7926,10 @@ void InGameUI::drawPlayerInfoList()
 				{
 					if (q[i].producer == producer)
 					{
-						overlayLog("DESTROYED: slot=%d building=%s unit=%s removed\n",
-							slot, q[i].buildingName.str(),
-							q[i].tmpl ? q[i].tmpl->getName().str() : "NULL");
+						const char* nameStr = q[i].tmpl ? q[i].tmpl->getName().str() :
+							(q[i].upgradeTmpl ? q[i].upgradeTmpl->getUpgradeName().str() : "UNKNOWN");
+						overlayLog("DESTROYED: slot=%d building=%s entry=%s removed\n",
+							slot, q[i].buildingName.str(), nameStr);
 						q.erase(q.begin() + i);
 						// don't increment i — erase shifts elements
 					}
@@ -8042,10 +8165,15 @@ void InGameUI::drawPlayerInfoList()
 					overlayLog("LAYOUT: draw ovIdx=%d ei=%zu row=%d col=%d ix=%d iy=%d (botY=%d)\n",
 						ovIdx, ei, row, col, ix, iy, bottomY);
 
-					// Try drawing the button image first
-					if (q[ei].tmpl && q[ei].tmpl->getButtonImage())
+					// Try drawing the button image (unit or upgrade)
+					const Image* img = nullptr;
+					if (q[ei].tmpl)
+						img = q[ei].tmpl->getButtonImage();
+					else if (q[ei].upgradeTmpl)
+						img = q[ei].upgradeTmpl->getButtonImage();
+
+					if (img)
 					{
-						const Image* img = q[ei].tmpl->getButtonImage();
 						TheDisplay->drawImage(img, ix, iy,
 							ix + iconSize, iy + iconSize);
 					}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -482,6 +482,19 @@ Bool SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj
 //-------------------------------------------------------------------------------------------------
 void SpecialPowerModule::triggerSpecialPower( const Coord3D *location )
 {
+	// TheSuperHackers @feature 14/07/2026 Notify overlay of power use at this location
+	// Must guard: TheInGameUI may not exist, location may be null, object may have no controller
+	if (TheInGameUI && location && getObject())
+	{
+		const Object* obj = getObject();
+		Player* player = obj ? obj->getControllingPlayer() : nullptr;
+		if (player)
+		{
+			TheInGameUI->onSpecialPowerTriggered(player,
+				getSpecialPowerTemplate(), *location);
+		}
+	}
+
 	aboutToDoSpecialPower( location );	// do BEFORE recharge
 
 	createViewObject(location);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -309,10 +309,14 @@ Bool ProductionUpdate::queueUpgrade( const UpgradeTemplate *upgrade )
 	production->m_type = PRODUCTION_UPGRADE;
 	production->m_upgradeToResearch = upgrade;
 	production->m_productionID = PRODUCTIONID_INVALID;  // not needed for upgrades, you can only have one of
-																	 // this type in the queue
+														 // this type in the queue
 
 	// tie to the end of the production queue
 	addToProductionQueue( production );
+
+	// TheSuperHackers @feature 17/07/2026 Notify observer overlay of queued upgrade
+	if (TheInGameUI)
+		TheInGameUI->onUpgradeQueued(getObject()->getControllingPlayer(), upgrade, getObject(), production->getPercentComplete());
 
 	// add this upgrade as in progress in the player
 	player->addUpgrade( upgrade, UPGRADE_STATUS_IN_PRODUCTION );
@@ -361,6 +365,10 @@ void ProductionUpdate::cancelUpgrade( const UpgradeTemplate *upgrade )
 	// refund money back to the player
 	Money *money = player->getMoney();
 	money->deposit( production->m_upgradeToResearch->calcCostToBuild( player ), TRUE, FALSE );
+
+	// TheSuperHackers @feature 17/07/2026 Notify observer overlay of cancelled upgrade
+	if (TheInGameUI)
+		TheInGameUI->onUpgradeCancelled(getObject()->getControllingPlayer(), production->m_upgradeToResearch, getObject());
 
 	// remove this production from the queue
 	removeFromProductionQueue( production );
@@ -988,6 +996,10 @@ UpdateSleepTime ProductionUpdate::update()
 					}
 				}
 			}
+
+			// TheSuperHackers @feature 17/07/2026 Notify overlay: upgrade completed production
+			if (TheInGameUI)
+				TheInGameUI->onUpgradeCompleted(player, upgrade, us);
 
 			// remove this production entry so we can go on to the next
 			removeFromProductionQueue( production );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -30,12 +30,16 @@
 // USER INCLUDES //////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
+#include <cstdarg>	// TheSuperHackers @debug 17/07/2026 va_list for prodOverlayLog
+#include <cstdio>	// TheSuperHackers @debug 17/07/2026 fopen/vfprintf for prodOverlayLog
+
 #include "Common/BitFlagsIO.h"
 #include "Common/BuildAssistant.h"
 #include "Common/CRCDebug.h"
 #include "Common/GameState.h"
 #include "Common/Player.h"
 #include "Common/Radar.h"
+#include "Common/Recorder.h"
 #include "Common/ThingFactory.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Upgrade.h"
@@ -55,6 +59,29 @@
 #include "GameLogic/Object.h"
 #include "GameLogic/ScriptEngine.h"
 
+
+
+// TheSuperHackers @debug 17/07/2026 Debug logging for upgrade-queue replay investigation.
+// Local copy of the overlayLog pattern (static in InGameUI.cpp) so this file logs to the same file.
+static FILE* g_prodOverlayLogFile = nullptr;
+static void prodOverlayLog(const char* fmt, ...)
+{
+	__try {
+		if (!g_prodOverlayLogFile) {
+			g_prodOverlayLogFile = fopen("genovly_debug.log", "a");
+		}
+		if (g_prodOverlayLogFile) {
+			va_list args;
+			va_start(args, fmt);
+			vfprintf(g_prodOverlayLogFile, fmt, args);
+			va_end(args);
+			fflush(g_prodOverlayLogFile);
+		}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+		// Logging itself failed -- silently ignore, never crash the game
+	}
+}
 
 // PUBLIC /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -260,6 +287,13 @@ CanMakeType ProductionUpdate::canQueueCreateUnit( const ThingTemplate *unitType 
 Bool ProductionUpdate::queueUpgrade( const UpgradeTemplate *upgrade )
 {
 
+	// TheSuperHackers @debug 17/07/2026 H1: does queueUpgrade() fire in replay mode?
+	prodOverlayLog("UPGRADE_HOOK: queueUpgrade() entry frame=%d replay=%d upgrade=%s obj=%s\n",
+		TheGameLogic ? (Int)TheGameLogic->getFrame() : -1,
+		(TheRecorder && TheRecorder->isPlaybackMode()) ? 1 : 0,
+		upgrade ? upgrade->getUpgradeName().str() : "NULL",
+		(getObject() && getObject()->getTemplate()) ? getObject()->getTemplate()->getName().str() : "NULL");
+
 	// sanity
 	if( upgrade == nullptr )
 		return FALSE;
@@ -270,19 +304,35 @@ Bool ProductionUpdate::queueUpgrade( const UpgradeTemplate *upgrade )
 	// sanity check to make sure we can build this upgrade
 	if( upgrade->getUpgradeType() == UPGRADE_TYPE_PLAYER &&
 			TheUpgradeCenter->canAffordUpgrade( player, upgrade ) == FALSE )
+	{
+		prodOverlayLog("UPGRADE_HOOK: queueUpgrade() early-return frame=%d reason=cannot_afford upgrade=%s\n",
+			TheGameLogic ? (Int)TheGameLogic->getFrame() : -1, upgrade->getUpgradeName().str());
 		return FALSE;
+	}
 	else if( upgrade->getUpgradeType() == UPGRADE_TYPE_OBJECT &&
 					 (getObject()->hasUpgrade( upgrade ) == TRUE ||
 					  getObject()->affectedByUpgrade( upgrade ) == FALSE) )
+	{
+		prodOverlayLog("UPGRADE_HOOK: queueUpgrade() early-return frame=%d reason=obj_has_or_unaffected upgrade=%s\n",
+			TheGameLogic ? (Int)TheGameLogic->getFrame() : -1, upgrade->getUpgradeName().str());
 		return FALSE;
+	}
 
 	// you cannot queue the production of an upgrade twice in this queue
 	if( isUpgradeInQueue( upgrade ) == TRUE )
+	{
+		prodOverlayLog("UPGRADE_HOOK: queueUpgrade() early-return frame=%d reason=already_in_queue upgrade=%s\n",
+			TheGameLogic ? (Int)TheGameLogic->getFrame() : -1, upgrade->getUpgradeName().str());
 		return FALSE;
+	}
 
 	// STOP cheaters by making sure they can actually build this
 	if( !getObject()->canProduceUpgrade(upgrade) )
+	{
+		prodOverlayLog("UPGRADE_HOOK: queueUpgrade() early-return frame=%d reason=cannot_produce upgrade=%s\n",
+			TheGameLogic ? (Int)TheGameLogic->getFrame() : -1, upgrade->getUpgradeName().str());
 		return FALSE;
+	}
 
 	//
 	// you cannot queue a player upgrade production if you are producing one already somewhere else
@@ -290,10 +340,16 @@ Bool ProductionUpdate::queueUpgrade( const UpgradeTemplate *upgrade )
 	//
 	if( upgrade->getUpgradeType() == UPGRADE_TYPE_PLAYER &&
       (player->hasUpgradeComplete( upgrade ) || player->hasUpgradeInProduction( upgrade )) )
+	{
+		prodOverlayLog("UPGRADE_HOOK: queueUpgrade() early-return frame=%d reason=player_has_or_in_prod upgrade=%s\n",
+			TheGameLogic ? (Int)TheGameLogic->getFrame() : -1, upgrade->getUpgradeName().str());
 		return FALSE;
+	}
 
 	if (m_productionCount >= getProductionUpdateModuleData()->m_maxQueueEntries)
 	{
+		prodOverlayLog("UPGRADE_HOOK: queueUpgrade() early-return frame=%d reason=queue_full upgrade=%s\n",
+			TheGameLogic ? (Int)TheGameLogic->getFrame() : -1, upgrade->getUpgradeName().str());
 		DEBUG_CRASH(("Production Queue is full... how did we get here?"));
 		return FALSE;
 	}
@@ -315,6 +371,8 @@ Bool ProductionUpdate::queueUpgrade( const UpgradeTemplate *upgrade )
 	addToProductionQueue( production );
 
 	// TheSuperHackers @feature 17/07/2026 Notify observer overlay of queued upgrade
+	prodOverlayLog("UPGRADE_HOOK: queueUpgrade() calling onUpgradeQueued frame=%d TheInGameUI=%p upgrade=%s\n",
+		TheGameLogic ? (Int)TheGameLogic->getFrame() : -1, (void*)TheInGameUI, upgrade->getUpgradeName().str());
 	if (TheInGameUI)
 		TheInGameUI->onUpgradeQueued(getObject()->getControllingPlayer(), upgrade, getObject(), production->getPercentComplete());
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -202,6 +202,9 @@ ProductionUpdate::ProductionUpdate( Thing *thing, const ModuleData* moduleData )
 //-------------------------------------------------------------------------------------------------
 ProductionUpdate::~ProductionUpdate()
 {
+	// TheSuperHackers @feature 15/07/2026 Notify overlay: building destroyed/sold
+	if (TheInGameUI)
+		TheInGameUI->onBuildingDestroyed(getObject());
 
 	// destroy any queued productions
 	ProductionEntry *production;
@@ -451,6 +454,10 @@ Bool ProductionUpdate::queueCreateUnit( const ThingTemplate *unitType, Productio
 	// tie to the end of the production queue
 	addToProductionQueue( production );
 
+	// TheSuperHackers @feature 15/07/2026 Notify observer overlay of queued unit
+	if (TheInGameUI)
+		TheInGameUI->onUnitQueued(getObject()->getControllingPlayer(), unitType, getObject(), production->getPercentComplete());
+
 	return TRUE;  // unit queued
 
 }
@@ -469,6 +476,13 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 		// are we at the one we want get rid of it
 		if( production->m_productionID == productionID )
 		{
+
+			// TheSuperHackers @feature 15/07/2026 Notify overlay BEFORE removing from queue
+			if (TheInGameUI && production->m_objectToProduce)
+			{
+				Player* p = getObject()->getControllingPlayer();
+				TheInGameUI->onUnitCancelled(p, production->m_objectToProduce, getObject());
+			}
 
 			// give the player the cost of the object back
 			Player *player = getObject()->getControllingPlayer();
@@ -675,6 +689,10 @@ UpdateSleepTime ProductionUpdate::update()
 		// remove from queue list
 		removeFromProductionQueue( production );
 
+		// TheSuperHackers @feature 15/07/2026 Notify observer overlay of cancelled unit
+		if (TheInGameUI)
+			TheInGameUI->onUnitCancelled(player, production->m_objectToProduce, getObject());
+
 		// delete the production entry
 		deleteInstance(production);
 
@@ -866,6 +884,10 @@ UpdateSleepTime ProductionUpdate::update()
 				{
 					// remove this production entry so we can go on to the next if we are totally finished
 					removeFromProductionQueue( production );
+
+					// TheSuperHackers @feature 15/07/2026 Notify overlay: unit completed production
+					if (TheInGameUI)
+						TheInGameUI->onUnitCompleted(player, production->m_objectToProduce, us);
 
 					// delete the production entry
 					deleteInstance(production);
@@ -1126,6 +1148,10 @@ UnsignedInt ProductionUpdate::countUnitTypeInQueue( const ThingTemplate *unitTyp
 // ------------------------------------------------------------------------------------------------
 void ProductionUpdate::onDie( const DamageInfo *damageInfo )
 {
+	// TheSuperHackers @feature 15/07/2026 Notify overlay to clear all queued units for this building
+	if (TheInGameUI)
+		TheInGameUI->onBuildingDestroyed(getObject());
+
 	// we need to cancel all of our production on death
 	cancelAndRefundAllProduction();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -115,8 +115,8 @@
 
 struct QuitGameException {};
 
-#include "../ngmp_include.h"
-#include "../ngmp_interfaces.h"
+#include "GameNetwork/GeneralsOnline/NGMP_include.h"
+#include "GameNetwork/GeneralsOnline/NGMP_interfaces.h"
 
 #include "../NextGenMP_defines.h"
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/NextGenTransport.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/NextGenTransport.cpp
@@ -4,8 +4,8 @@
 #include "GameNetwork/NetworkInterface.h"
 #include "GameNetwork/GeneralsOnline/NextGenTransport.h"
 
-#include "GameNetwork/GeneralsOnline/ngmp_include.h"
-#include "GameNetwork/GeneralsOnline/ngmp_interfaces.h"
+#include "GameNetwork/GeneralsOnline/NGMP_include.h"
+#include "GameNetwork/GeneralsOnline/NGMP_interfaces.h"
 #include "ValveNetworkingSockets/steam/steamnetworkingtypes.h"
 #include "GameNetwork/GeneralsOnline/PluginInterfaces.h"
 

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -41,6 +41,29 @@
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
 #include "WinMain.h"
+
+#include <cstdarg>	// TheSuperHackers @debug 18/07/2026 va_list for traceLog
+#include <cstdio>	// TheSuperHackers @debug 18/07/2026 fopen/vfprintf for traceLog
+
+// TheSuperHackers @debug 18/07/2026 Startup-chain tracing — audio investigation.
+static FILE* g_traceLogFile_winmain = nullptr;
+static void traceLog(const char* fmt, ...)
+{
+	__try {
+		if (!g_traceLogFile_winmain) {
+			g_traceLogFile_winmain = fopen("genovly_debug.log", "a");
+		}
+		if (g_traceLogFile_winmain) {
+			va_list args;
+			va_start(args, fmt);
+			vfprintf(g_traceLogFile_winmain, fmt, args);
+			va_end(args);
+			fflush(g_traceLogFile_winmain);
+		}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) {
+	}
+}
 #include "Lib/BaseType.h"
 #include "Common/CommandLine.h"
 #include "Common/CriticalSection.h"
@@ -806,6 +829,9 @@ Int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 {
 	Int exitcode = 1;
 
+	// TheSuperHackers @debug 18/07/2026 Build marker — proves which exe actually ran
+	traceLog("TRACE: WINMAIN entry — genovly audio-v2 build 18-07-2026\n");
+
 #ifdef RTS_PROFILE_LEGACY
 	Profile::StartRange("init");
 #endif
@@ -878,6 +904,7 @@ Int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		gLoadScreenBitmap = (HBITMAP)LoadImage(hInstance, "Install_Final.bmp", IMAGE_BITMAP, 0, 0, LR_SHARED | LR_LOADFROMFILE);
 #endif
 
+		traceLog("TRACE: splash gLoadScreenBitmap=%p\n", (void*)gLoadScreenBitmap);
 		CommandLine::parseCommandLineForStartup();
 #ifdef RTS_ENABLE_CRASHDUMP
 		// Initialize minidump facilities - requires TheGlobalData so performed after parseCommandLineForStartup

--- a/resources/dockerbuild-msvc/entrypoint.sh
+++ b/resources/dockerbuild-msvc/entrypoint.sh
@@ -123,4 +123,10 @@ echo "Fixed paths: ${FIXED} occurrences with Z: prefix"
 
 # Build - pass MSVC environment into the Windows cmd session
 cd "${BUILD_DIR}"
-wine cmd /c "set TMP=Z:\build\tmp& set TEMP=Z:\build\tmp& set INCLUDE=${INCLUDE}& set LIB=${LIB}& set LIBPATH=${LIBPATH}& set PATH=${WINEPATH};%PATH%& Z:\build\tools\ninja.exe ${MAKE_TARGET:-z_generals}"
+wine cmd /c "set TMP=Z:\\build\\tmp& set TEMP=Z:\\build\\tmp& set INCLUDE=${INCLUDE}& set LIB=${LIB}& set LIBPATH=${LIBPATH}& set PATH=${WINEPATH};%PATH%& Z:\\build\\tools\\ninja.exe ${MAKE_TARGET:-z_generals}"
+
+# Deploy: copy the built executable to the deploy directory
+DEPLOY_DIR="/build/cnc/build/deploy"
+mkdir -p "${DEPLOY_DIR}"
+cp "${BUILD_DIR}/GeneralsMD/GeneralsOnlineZH.exe" "${DEPLOY_DIR}/GeneralsOnlineZH.exe"
+echo "Deployed: ${DEPLOY_DIR}/GeneralsOnlineZH.exe"

--- a/resources/dockerbuild-msvc/entrypoint.sh
+++ b/resources/dockerbuild-msvc/entrypoint.sh
@@ -11,7 +11,16 @@ wineboot --init 2>/dev/null || true
 
 # MSVC paths - replicate what msvcenv.sh sets
 BASE="Z:\\build\\tools\\msvc"
-MSVCVER="14.50.35717"
+# Detect MSVC version dynamically to stay in sync with what vsdownload.py installed
+# Fallback to hardcoded defaults if detection fails
+MSVC_DIR="/build/tools/msvc/VC/Tools/MSVC"
+if [ -d "$MSVC_DIR" ]; then
+    MSVCVER=$(ls "$MSVC_DIR" | sort -V | tail -1)
+    echo "Detected MSVC version: $MSVCVER"
+else
+    MSVCVER="14.51.36231"
+    echo "Using default MSVC version: $MSVCVER"
+fi
 SDKVER="10.0.26100.0"
 ARCH="x86"
 
@@ -47,6 +56,13 @@ RC_COMPILER="Z:/build/tools/msvc/WindowsKits/10/bin/${SDKVER}/x64/rc.exe"
 RC_INCLUDE="Z:/build/tools/msvc/WindowsKits/10/Include/${SDKVER}"
 RC_FLAGS="-I \"${RC_INCLUDE}/um\" -I \"${RC_INCLUDE}/shared\""
 
+# Derive compiler version info from detected MSVCVER
+COMPILER_MAJOR="19"
+COMPILER_MINOR=$(echo $MSVCVER | cut -d. -f2)
+COMPILER_BUILD=$(echo $MSVCVER | cut -d. -f3)
+COMPILER_FULL="${COMPILER_MAJOR}.${COMPILER_MINOR}.${COMPILER_BUILD}"
+MSVC_NUM="${COMPILER_MAJOR}${COMPILER_MINOR}"
+
 # Configure if needed
 if [ "${FORCE_CMAKE:-}" = "true" ] || [ ! -f "${BUILD_DIR}/build.ninja" ]; then
 	rm -f "${BUILD_DIR}/CMakeCache.txt"
@@ -62,9 +78,9 @@ if [ "${FORCE_CMAKE:-}" = "true" ] || [ ! -f "${BUILD_DIR}/build.ninja" ]; then
 		-DCMAKE_LINKER="${LINK_WIN}" \
 		-DCMAKE_C_COMPILER_ID=MSVC \
 		-DCMAKE_CXX_COMPILER_ID=MSVC \
-		-DCMAKE_C_COMPILER_VERSION=19.50.35726 \
-		-DCMAKE_CXX_COMPILER_VERSION=19.50.35726 \
-		-DMSVC_VERSION=1950 \
+		-DCMAKE_C_COMPILER_VERSION="${COMPILER_FULL}" \
+		-DCMAKE_CXX_COMPILER_VERSION="${COMPILER_FULL}" \
+		-DMSVC_VERSION="${MSVC_NUM}" \
 		-DMSVC=1 \
 		-DCMAKE_C_STANDARD_COMPUTED_DEFAULT=17 \
 		-DCMAKE_C_EXTENSIONS_COMPUTED_DEFAULT=OFF \


### PR DESCRIPTION
Audio tracing (genovly\_debug.log) toegevoegd in de startup-chain:
- WinMain/GameMain/GameEngine init tracing
- MilesAudioManager::openDevice volledige pad-logging
- SubsystemInterface initSubsystem entry/exit

Overlay upgrade-queue debug logging in:
- ProductionUpdate::queueUpgrade (alle early-return redenen)
- InGameUI onUpgradeQueued/onUpgradeCompleted/onUpgradeCancelled

7 files changed, 246 insertions(+), 2 deletions(-)