### PR TITLE
fix: redact RNG seed from HTTP response logging in release builds

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/HTTP/HTTPRequest.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/HTTP/HTTPRequest.cpp
@@ -208,6 +208,18 @@ void HTTPRequest::Threaded_SetComplete(CURLcode result)
 	// if we got an error, set the response code to 0
 
 #if !_DEBUG
+	static const std::string strSeedKey = "\"RNGSeed\":";
+	for (size_t seedPos = strResponse.find(strSeedKey); seedPos != std::string::npos; seedPos = strResponse.find(strSeedKey, seedPos))
+	{
+		size_t valueStart = seedPos + strSeedKey.length();
+		size_t valueEnd = strResponse.find_first_of(",}", valueStart);
+		if (valueEnd == std::string::npos)
+			break;
+
+		strResponse.replace(valueStart, valueEnd - valueStart, "<redacted>");
+		seedPos = valueStart;
+	}
+
 	std::transform(strResponse.begin(), strResponse.end(), strResponse.begin(),
 		[](unsigned char c) { return std::tolower(c); });
 	if (strResponse.find("token") != std::string::npos)


### PR DESCRIPTION
`HTTPRequest::Threaded_SetComplete` logs the raw body of every HTTP response.
`GET /Lobby/{id}` and `GET /Lobbies` both serialize the full `Lobby` object, so
each response carries `RNGSeed` — one per entry for the lobby list. The seed for
a match ends up in `GeneralsOnline.log` in the clear before the game starts, and
that has avenues for potential abuse.