### PR TITLE
Increase default GameWindowTransitionSpeedMultiplier to 3

### DIFF
--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -972,7 +972,7 @@ Real OptionPreferences::getGameWindowTransitionSpeedMultiplier() const
 {
 	OptionPreferences::const_iterator it = find("GameWindowTransitionSpeedMultiplier");
 	if (it == end())
-		return 1.0f;
+		return 3.0f;
 
 	Real speed = (Real) atof(it->second.str());
 	return clamp(1.0f, speed, 1000.0f);

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -958,7 +958,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_gameWindowTransitionSpeedMultiplier = 1.0f;
+	m_gameWindowTransitionSpeedMultiplier = 3.0f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -976,7 +976,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_gameWindowTransitionSpeedMultiplier = 1.0f;
+	m_gameWindowTransitionSpeedMultiplier = 3.0f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 


### PR DESCRIPTION
This updates the default menu/window transition speed so animations feel more responsive out of the box.

`GameWindowTransitionSpeedMultiplier` default is changed from `1.0` to `3.0` in:
- [Core/GameEngine/Source/Common/OptionPreferences.cpp](Core/GameEngine/Source/Common/OptionPreferences.cpp)
- [Generals/Code/GameEngine/Source/Common/GlobalData.cpp](Generals/Code/GameEngine/Source/Common/GlobalData.cpp)
- [GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp](GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp)

---

The previous default of `1` makes UI transitions feel too slow (including menus such as general promotions). Setting the default to `3` provides a better baseline user experience.

<img width="534" height="303" alt="image" src="https://github.com/user-attachments/assets/685714d6-c67a-47af-ac4e-86bd0bd3683a" />

<img width="588" height="507" alt="image" src="https://github.com/user-attachments/assets/7645ebe2-66b4-4dc3-a30d-a449406c740a" />

---

- Existing users who already have `GameWindowTransitionSpeedMultiplier` explicitly set in `Options.ini` keep their chosen value.
- New installs, missing-key cases, and reset/default paths now use `3`.