### PR TITLE
Increase default GameWindowTransitionSpeedMultiplier to 2.5

### DIFF
--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -972,7 +972,7 @@ Real OptionPreferences::getGameWindowTransitionSpeedMultiplier() const
 {
 	OptionPreferences::const_iterator it = find("GameWindowTransitionSpeedMultiplier");
 	if (it == end())
-		return 1.0f;
+		return 2.5f;
 
 	Real speed = (Real) atof(it->second.str());
 	return clamp(1.0f, speed, 1000.0f);

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -958,7 +958,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_gameWindowTransitionSpeedMultiplier = 1.0f;
+	m_gameWindowTransitionSpeedMultiplier = 2.5f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -976,7 +976,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_gameWindowTransitionSpeedMultiplier = 1.0f;
+	m_gameWindowTransitionSpeedMultiplier = 2.5f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 


### PR DESCRIPTION
Sets the GameWindowTransitionSpeedMultiplier default from 1.0 to 2.5 for the OptionPreferences fallback and the GlobalData constructors in Generals and GeneralsMD.

GUI transitions were previously advanced one animation frame per rendered frame, so players on high frame rates experienced much faster menu animations. Now that transition timing is frame rate independent, the original 1.0 default feels far slower than what players are used to, including menus such as general promotions. A default of 2.5 restores some semblance of normalcy.

---

Users whose `Options.ini` already contains `GameWindowTransitionSpeedMultiplier` keep their existing value.