### PR TITLE
- Add command line override to disable the community data patch

### DIFF
--- a/Core/GameEngine/Source/Common/System/ArchiveFileSystem.cpp
+++ b/Core/GameEngine/Source/Common/System/ArchiveFileSystem.cpp
@@ -235,7 +235,8 @@ void ArchiveFileSystem::loadMods()
 {
 #if defined(GENERALS_ONLINE) && defined(GENERALS_ONLINE_COMMUNITY_PATCH_CHANGES)
     // load community data patch BIG
-	if (NGMP_OnlineServicesManager::Settings.DataPacks_UseCommunityPatch())
+	if (NGMP_OnlineServicesManager::Settings.DataPacks_UseCommunityPatch()
+		&& !TheGlobalData->m_commandLineData.isCommunityDataPatchDisabled())
     {
         std::string strBigPath = std::format("{}GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big", TheGlobalData->getPath_UserData().str());
         bool bLoaded = false;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -59,13 +59,20 @@ class CommandLineData
 	friend class CommandLine;
 	friend class GlobalData;
 
+public:
+	Bool isCommunityDataPatchDisabled() const { return m_disableCommunityDataPatch; }
+	void disableCommunityDataPatch() { m_disableCommunityDataPatch = true; }
+
+private:
 	CommandLineData()
 		: m_hasParsedCommandLineForStartup(false)
 		, m_hasParsedCommandLineForEngineInit(false)
+		, m_disableCommunityDataPatch(false)
 	{}
 
 	Bool m_hasParsedCommandLineForStartup;
 	Bool m_hasParsedCommandLineForEngineInit;
+	Bool m_disableCommunityDataPatch;
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -1126,6 +1126,13 @@ Int parseMod(char *args[], Int num)
 	return 1;
 }
 
+Int parseDisableCommunityDataPatch(char *args[], Int num)
+{
+	TheWritableGlobalData->m_commandLineData.disableCommunityDataPatch();
+
+	return 1;
+}
+
 #ifdef DEBUG_LOGGING
 Int parseSetDebugLevel(char *args[], int num)
 {
@@ -1207,6 +1214,7 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-scriptDebug", parseScriptDebug },
 	{ "-playStats", parsePlayStats },
 	{ "-mod", parseMod },
+	{ "-disableCommunityDataPatch", parseDisableCommunityDataPatch },
 	{ "-noshaders", parseNoShaders },
 	{ "-quickstart", parseQuickStart },
 	{ "-useWaveEditor", parseUseWaveEditor },


### PR DESCRIPTION
Adds `-disableCommunityDataPatch`, a command-line override that skips loading the Community Data Patch for the current launch without changing the saved setting.

This allows mod launchers to run mods without risking compatibility issues with the Community Data Patch, while preserving the user’s preference for normal game launches.

## Validation
 - [x] Tested settings included case-insensitive parsing, existing arguments, and persistence.
 - [x] All builds pass