### PR TITLE
- Restore quickstart, nologo, and noshellmap functionality

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/NextGenMP_defines.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/NextGenMP_defines.h
@@ -103,11 +103,6 @@ static int FRAME_GROUPING_CAP = 64;
 #define GENERALS_ONLINE_USE_SENTRY 1
 #endif
 
-// NOTE: This is temporary until we work out why this causes mismatch when some players set it and others dont
-#if !_DEBUG
-#define GENERALS_ONLINE_DISABLE_QUICKSTART_FUNCTIONALITY 1
-#endif
-
 #define GENERALS_ONLINE_WIDESCREEN 1
 
 #if defined(GENERALS_ONLINE_WIDESCREEN)

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -789,10 +789,6 @@ Int parseSync(char *args[], int)
 
 Int parseNoShellMap(char *args[], int)
 {
-#if defined(GENERALS_ONLINE_DISABLE_QUICKSTART_FUNCTIONALITY)
-	return 1;
-#endif
-
 	TheWritableGlobalData->m_shellMapOn = FALSE;
 
 	return 1;
@@ -805,22 +801,9 @@ Int parseNoShaders(char *args[], int)
 	return 1;
 }
 
-#if defined(RTS_DEBUG) || !defined(GENERALS_ONLINE_DISABLE_QUICKSTART_FUNCTIONALITY)
 Int parseNoLogo(char *args[], int)
 {
 	TheWritableGlobalData->m_playIntro = FALSE;
-	TheWritableGlobalData->m_playSizzle = FALSE;
-
-	return 1;
-}
-#endif
-
-Int parseNoSizzle( char *args[], int )
-{
-#if defined(GENERALS_ONLINE_DISABLE_QUICKSTART_FUNCTIONALITY)
-	return 1;
-#endif
-
 	TheWritableGlobalData->m_playSizzle = FALSE;
 
 	return 1;
@@ -851,17 +834,7 @@ Int parseWinCursors(char *args[], int num)
 
 Int parseQuickStart( char *args[], int num )
 {
-#if defined(GENERALS_ONLINE_DISABLE_QUICKSTART_FUNCTIONALITY)
-	return 1;
-#endif
-
-#if defined(RTS_DEBUG) || !defined(GENERALS_ONLINE_DISABLE_QUICKSTART_FUNCTIONALITY)
-  parseNoLogo( args, num );
-#else
-	//Kris: Patch 1.01 -- Allow release builds to skip the sizzle video, but still force the EA logo to show up.
-	//This is for legal reasons.
-	parseNoSizzle( args, num );
-#endif
+	parseNoLogo( args, num );
 	parseNoShellMap( args, num );
 	parseNoWindowAnimation( args, num );
 	return 1;
@@ -1195,9 +1168,7 @@ static CommandLineParam paramsForStartup[] =
 // These Params are parsed during Engine Init before INI data is loaded
 static CommandLineParam paramsForEngineInit[] =
 {
-#if defined(RTS_DEBUG) || !defined(GENERALS_ONLINE_DISABLE_QUICKSTART_FUNCTIONALITY)
 	{ "-nologo", parseNoLogo }, // TheSuperHackers @tweak Is now available in Release builds.
-#endif
 	{ "-noshellmap", parseNoShellMap },
 	{ "-noShellAnim", parseNoWindowAnimation }, // TheSuperHackers @tweak Is now available in Release builds.
 	{ "-xres", parseXRes },


### PR DESCRIPTION
Restores `-quickstart`, `-nologo`, and `-noshellmap`. The original mismatch issue was fixed in TheSuperHackers/GeneralsGameCode#1234, so unless there is another reason for them that I’m unaware of, the guard is obsolete.

## Validation

- [x] All builds passed
- [x] Tested the restored CLI arguments