### PR TITLE
- Fix Supply Drop crate payouts at 60Hz

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeletionUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeletionUpdate.h
@@ -72,6 +72,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	void setLifetimeRange( UnsignedInt minFrames, UnsignedInt maxFrames );
+	void restartLifetime();
 	UnsignedInt getDieFrame() { return m_dieFrame; }
 
 	virtual UpdateSleepTime update() override;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/ParachuteContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/ParachuteContain.cpp
@@ -39,6 +39,7 @@
 #include "GameLogic/AIPathfind.h"
 #include "GameLogic/Locomotor.h"
 #include "GameLogic/Module/AIUpdate.h"
+#include "GameLogic/Module/DeletionUpdate.h"
 #include "GameLogic/Module/ParachuteContain.h"
 #include "GameLogic/Module/PhysicsUpdate.h"
 #include "GameLogic/Object.h"
@@ -469,6 +470,16 @@ void ParachuteContain::onRemoving( Object *rider )
 	const ParachuteContainModuleData* d = getParachuteContainModuleData();
 
 	// object is no longer held inside a transport
+#if defined(GENERALS_ONLINE_HIGH_FPS_SERVER)
+	// Info: At 60Hz, a short-lived object can reach its DeletionUpdate lifetime while parachuting, then be destroyed
+	// before its delayed OCLUpdate runs after landing. Restart an expired lifetime before releasing the object.
+	static NameKeyType key_DeletionUpdate = NAMEKEY( "DeletionUpdate" );
+	DeletionUpdate *dup = (DeletionUpdate*)rider->findUpdateModule( key_DeletionUpdate );
+	if (dup && dup->getDieFrame() <= TheGameLogic->getFrame())
+	{
+		dup->restartLifetime();
+	}
+#endif
 	rider->clearDisabled( DISABLED_HELD );
 	rider->clearStatus( MAKE_OBJECT_STATUS_MASK( OBJECT_STATUS_PARACHUTING ) );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DeletionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DeletionUpdate.cpp
@@ -69,6 +69,14 @@ void DeletionUpdate::setLifetimeRange( UnsignedInt minFrames, UnsignedInt maxFra
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
+void DeletionUpdate::restartLifetime()
+{
+	const DeletionUpdateModuleData *d = getDeletionUpdateModuleData();
+	setLifetimeRange( d->m_minFrames, d->m_maxFrames );
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
 UnsignedInt DeletionUpdate::calcSleepDelay(UnsignedInt minFrames, UnsignedInt maxFrames)
 {
 	UnsignedInt delay = GameLogicRandomValue( minFrames, maxFrames );


### PR DESCRIPTION
Restarts an expired `DeletionUpdate` lifetime before a parachuted object is released at 60Hz.

This prevents short-lived Supply Drop dummy crates from being destroyed on landing before their delayed `OCLUpdate` creates the real money crate.

## Validation

- [x] Release build passed
- [x] Tested the Supply Drop Zone from ShockWave mod.