### PR TITLE
- Fix archive map resolution in online lobbies

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_LobbyInterface.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_LobbyInterface.cpp
@@ -9,6 +9,35 @@ extern void OnKickedFromLobby();
 
 extern NGMPGame* TheNGMPGame;
 
+namespace
+{
+	std::string ResolveLobbyMapPath(const std::string& relativeMapPath, bool isOfficial)
+	{
+		const std::string systemMapPath = std::format("maps\\{}", relativeMapPath);
+		if (isOfficial)
+		{
+			return systemMapPath;
+		}
+
+		// Match retail map-list precedence: an unofficial map packaged under Maps wins an
+		// ambiguous collision with a map of the same name in the user map directory.
+		const MapMetaData* systemMapData = TheMapCache->findMap(AsciiString(systemMapPath.c_str()));
+		if (systemMapData != nullptr && !systemMapData->m_isOfficial)
+		{
+			return systemMapPath;
+		}
+
+		const std::string userMapPath = std::format("{}\\{}", TheMapCache->getUserMapDir(true).str(), relativeMapPath);
+		if (TheMapCache->findMap(AsciiString(userMapPath.c_str())) != nullptr)
+		{
+			return userMapPath;
+		}
+
+		// Preserve the existing missing-map path so normal custom-map transfer behavior is unchanged.
+		return userMapPath;
+	}
+}
+
 struct JoinLobbyResponse
 {
 	bool success = false;
@@ -595,15 +624,7 @@ void NGMP_OnlineServices_LobbyInterface::SearchForLobbies(std::function<void()> 
 				}
 				++latencyIndex;
 
-				// correct map path
-				if (lobbyEntry.map_official)
-				{
-					lobbyEntry.map_path = std::format("maps\\{}", lobbyEntry.map_path.c_str());
-				}
-				else
-				{
-					lobbyEntry.map_path = std::format("{}\\{}", TheMapCache->getUserMapDir(true).str(), lobbyEntry.map_path.c_str());
-				}
+				lobbyEntry.map_path = ResolveLobbyMapPath(lobbyEntry.map_path, lobbyEntry.map_official);
 
 				// NOTE: These fields won't be present becauase they're private properties
 				//memberEntryIter["enc_key"].get_to(strEncKey);
@@ -858,19 +879,7 @@ void NGMP_OnlineServices_LobbyInterface::UpdateRoomDataCache(std::function<void(
 						// store, we'll need it later and lobby obj gets destroyed on leave
 						m_CurrentMatchID = lobbyEntry.match_id;
 
-						// correct map path
-						if (lobbyEntry.map_official)
-						{
-							lobbyEntry.map_path = std::format("maps\\{}", lobbyEntry.map_path.c_str());
-						}
-						else
-						{
-							// TODO_NGMP: This needs to match identically, but why did it change from the base game?
-							AsciiString strUserMapDIr = TheMapCache->getUserMapDir(true);
-							strUserMapDIr.toLower();
-
-							lobbyEntry.map_path = std::format("{}\\{}", strUserMapDIr.str(), lobbyEntry.map_path.c_str());
-						}
+						lobbyEntry.map_path = ResolveLobbyMapPath(lobbyEntry.map_path, lobbyEntry.map_official);
 
 						// did the map change? cache that we need to reset and transmit our ready state
 						bool bNeedsHasMapUpdate = false;


### PR DESCRIPTION
Resolves unofficial maps packaged in BIG archives through the map cache before falling back to the user Documents map directory.

This restores retail map precedence and prevents archive-provided mod maps from being incorrectly reported as missing and queued for transfer in Generals Online lobbies.

## Validation

- [x] Release build passed
- [x] Tested in Online Lobby with both Operation Firestorm and Contra Mods.