### PR TITLE
- Fix projectile launch orientation at 60Hz

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -661,7 +661,18 @@ UpdateSleepTime DumbProjectileBehavior::update()
 			if (m_flightPath.size() >= 2)
 			{
 				prevPos = m_flightPath[0];
+#if defined(GENERALS_ONLINE_HIGH_FPS_SERVER)
+				// Info: Look one legacy frame ahead so launch orientation matches the retail 30Hz path.
+				const Int highFpsPathPointCount = (Int)m_flightPath.size();
+				const Int legacyPathPointCount = (highFpsPathPointCount + GENERALS_ONLINE_HIGH_FPS_FRAME_MULTIPLIER - 1)
+					/ GENERALS_ONLINE_HIGH_FPS_FRAME_MULTIPLIER;
+				const Int legacyPathIntervalCount = max(legacyPathPointCount - 1, 1);
+				const Int orientationStep = (highFpsPathPointCount - 1 + legacyPathIntervalCount / 2)
+					/ legacyPathIntervalCount;
+				curPos = m_flightPath[orientationStep];
+#else
 				curPos = m_flightPath[1];
+#endif
 			}
 			else
 			{


### PR DESCRIPTION
Uses the projectile path point corresponding to one legacy frame when calculating launch orientation at 60Hz.

This prevents fast curved-path projectiles and their attached tracers from initially pointing toward an intermediate elevated path point instead of the target. The issue was discovered in Shockwave Chaos Mod.

## Validation

- [x] Release build passed
- [x] Tested the Battle Master, Gatling Tank, and Gatling Cannon tracers in Shockwave Chaos Mod.