### PR TITLE
- Fix one-frame attached particle visibility at 60Hz

### DIFF
--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1430,7 +1430,16 @@ void ParticleSystem::rotateLocalTransformZ( Real z )
 void ParticleSystem::attachToDrawable( const Drawable *draw )
 {
 	if (draw)
+	{
 		m_attachedToDrawableID = draw->getID();
+
+#if defined(GENERALS_ONLINE_HIGH_FPS_RENDER)
+		// Info: One-frame attached systems can otherwise lose their only burst when the drawable is created and destroyed
+		// between legacy particle updates at 60Hz.
+		if (m_systemLifetimeLeft == 1 && m_delayLeft == 0 && getParticleCount() == 0)
+			update(0);
+#endif
+	}
 	else
 		m_attachedToDrawableID = INVALID_DRAWABLE_ID;
 }


### PR DESCRIPTION
Updates one-frame particle systems when they are attached to a drawable at 60Hz.

This prevents short-lived projectile drawables from being destroyed between legacy particle updates before their attached effect emits its only particle burst. The issue was discovered in Shockwave Chaos Mod.

## Validation

- [x] Release build passed
- [x] Tested the Battle Master, Gatling Tank, and Gatling Cannon tracers in Shockwave Chaos Mod.