### PR TITLE
- Fix delayed particle effect timing at 60Hz

### DIFF
--- a/Core/GameEngine/Source/GameClient/FXList.cpp
+++ b/Core/GameEngine/Source/GameClient/FXList.cpp
@@ -647,8 +647,12 @@ protected:
 					Real delayInMsec = m_delay.getValue();
 					if (delayInMsec >= 0.0f)
 					{
-						UnsignedInt delayInFrames = REAL_TO_INT_CEIL(ConvertDurationFromMsecsToFrames(delayInMsec));
-						sys->setInitialDelay(delayInFrames);
+						Real delayInFrames = ConvertDurationFromMsecsToFrames(delayInMsec);
+#if defined(GENERALS_ONLINE_HIGH_FPS_RENDER)
+						// Info: Particle systems update on legacy frames, so their delays must use the same cadence at 60Hz.
+						delayInFrames /= GENERALS_ONLINE_HIGH_FPS_FRAME_MULTIPLIER;
+#endif
+						sys->setInitialDelay(REAL_TO_INT_CEIL(delayInFrames));
 					}
 
 					if( m_useCallersRadius  &&  overrideRadius )


### PR DESCRIPTION
Converts FX particle-system initial delays to the legacy particle update cadence at 60Hz.

This restores retail timing for effects composed of sequentially delayed particle systems and prevents visible gaps and rapid flickering between effect stages. The issue was discovered in Contra.

## Validation

- [x] Release build passed
- [x] Tested projectile impact and artillery explosion effects in Contra.