### PR TITLE
- Fix list box theme colors

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -1163,8 +1163,12 @@ void RefreshGameListBox(GameWindow* win, Bool showMap)
 	pLobbyInterface->SearchForLobbies(
 		[=]()
 		{
-			win->winEnable(false);
-			GadgetListBoxAddEntryText(win, UnicodeString(L"Searching for public lobbies..."), GameMakeColor(255, 194, 15, 255), -1, -1);
+			win->winEnable(true);
+			if (GadgetListBoxGetNumEntries(win) == 0)
+			{
+				GadgetListBoxAddEntryText(win, UnicodeString(L"Searching for public lobbies..."), GameMakeColor(255, 194, 15, 255), -1, -1);
+				GadgetListBoxSetSelected(win, -1);
+			}
 		},
 		[=](std::vector<LobbyEntry> vecLobbies)
 		{
@@ -1173,11 +1177,10 @@ void RefreshGameListBox(GameWindow* win, Bool showMap)
 
 			size_t numResults = vecLobbies.size();
 
-			GadgetListBoxReset(win);
 			if (numResults == 0)
 			{
-				win->winEnable(false);
 				GadgetListBoxAddEntryText(win, UnicodeString(L"No lobbies were found"), GameMakeColor(255, 194, 15, 255), -1, -1);
+				GadgetListBoxSetSelected(win, -1);
 
 			}
 			else
@@ -1196,8 +1199,8 @@ void RefreshGameListBox(GameWindow* win, Bool showMap)
 					vecLobbies = filtered;
 					if (vecLobbies.empty())
 					{
-						win->winEnable(false);
 						GadgetListBoxAddEntryText(win, UnicodeString(L"No lobbies currently match this filter"), GameMakeColor(255, 194, 15, 255), -1, -1);
+						GadgetListBoxSetSelected(win, -1);
 						return;
 					}
 				}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp
@@ -195,9 +195,6 @@ static void drawListBoxText( GameWindow *window, WinInstanceData *instData,
 	IRegion2D clipRegion;
 	ICoord2D start, end;
 
-    Color WindowBg = TheWindowManager->winMakeColor(3, 93, 166, 20);
-	TheWindowManager->winFillRect(WindowBg, WIN_DRAW_LINE_WIDTH, x, y, x + width, y + height);
-
 	//
 	// save the clipping information region cause we're going to use it here
 	// in drawing the text

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -2327,7 +2327,8 @@ WindowMsgHandledType WOLLobbyMenuSystem( GameWindow *window, UnsignedInt msg,
 				if ( controlID == GetGameListBoxID() )
 				{
 					int rowSelected = mData2;
-					if( rowSelected >= 0 )
+					Int lobbyID = rowSelected >= 0 ? (Int)GadgetListBoxGetItemData(control, rowSelected, 0) : 0;
+					if( lobbyID > 0 )
 					{
 						buttonJoin->winEnable(TRUE);
 						static UnsignedInt lastFrame = 0;
@@ -2336,7 +2337,7 @@ WindowMsgHandledType WOLLobbyMenuSystem( GameWindow *window, UnsignedInt msg,
 
 						PeerRequest req;
 						req.peerRequestType = PeerRequest::PEERREQUEST_GETEXTENDEDSTAGINGROOMINFO;
-						req.stagingRoom.id = (Int)GadgetListBoxGetItemData(control, rowSelected, 0);
+						req.stagingRoom.id = lobbyID;
 
 						if (lastID != req.stagingRoom.id || now > lastFrame + 60)
 						{
@@ -2411,7 +2412,7 @@ WindowMsgHandledType WOLLobbyMenuSystem( GameWindow *window, UnsignedInt msg,
 					if (selected >= 0)
 					{
 						Int selectedID = (Int)GadgetListBoxGetItemData(GetGameListBox(), selected);
-						if (selectedID >= 0)
+						if (selectedID > 0)
 						{
 							auto Lobby = pLobbyInterface->GetLobbyFromID(selectedID);
 


### PR DESCRIPTION
Removes the hardcoded translucent blue overlay from list box rendering so colors supplied by WND files are displayed unchanged.

Generals Online previously disabled the lobby list while searching or showing no results, which exposes the scrollbar’s yellow disabled-state styling once the overlay is removed. The list now remains enabled, only displays the searching status when empty, and accepts Join actions only for rows containing valid lobby IDs.

## Validation

- [x] Release build passes.
- [x] Tested list box colors in LAN and Online Lobbies with Operation Firestorm and Contra mods.
- [x] Tested online and game lobbies.