### PR TITLE
bugfix(gui): Remove destroyed windows from the modal stack

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameWindowManager.h
@@ -331,6 +331,7 @@ public:
 protected:
 
 	void processDestroyList();  ///< process windows waiting to be killed
+	void removeWindowFromModalStack( GameWindow *window );
 
 	Int drawWindow( GameWindow *window );  ///< draw this window
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -103,9 +103,6 @@ void GameWindowManager::processDestroyList()
 		if( m_keyboardFocus == doDestroy )
 			winSetFocus( nullptr );
 
-		if( (m_modalHead != nullptr) && (doDestroy == m_modalHead->window) )
-			winUnsetModal( m_modalHead->window );
-
 		if( m_currMouseRgn == doDestroy )
 			m_currMouseRgn = nullptr;
 
@@ -1519,8 +1516,7 @@ Int GameWindowManager::winDestroy( GameWindow *window )
 	if( m_keyboardFocus == window )
 		winSetFocus( nullptr );
 
-	if( (m_modalHead != nullptr) && (window == m_modalHead->window) )
-		winUnsetModal( m_modalHead->window );
+	removeWindowFromModalStack( window );
 
 	if( m_currMouseRgn == window )
 		m_currMouseRgn = nullptr;
@@ -1650,6 +1646,26 @@ Int GameWindowManager::winUnsetModal( GameWindow *window )
 
 	return WIN_ERR_OK;
 
+}
+
+// TheSuperHackers @bugfix arcticdolphin 27/08/2026 Remove destroyed windows from the entire modal stack.
+void GameWindowManager::removeWindowFromModalStack( GameWindow *window )
+{
+	ModalWindow **link = &m_modalHead;
+
+	while( *link )
+	{
+		ModalWindow *modal = *link;
+
+		if( modal->window != window )
+		{
+			link = &modal->next;
+			continue;
+		}
+
+		*link = modal->next;
+		deleteInstance(modal);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
@@ -335,6 +335,7 @@ public:
 protected:
 
 	void processDestroyList();  ///< process windows waiting to be killed
+	void removeWindowFromModalStack( GameWindow *window );
 
 	Int drawWindow(GameWindow* window);  ///< draw this window
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -103,11 +103,10 @@ void GameWindowManager::processDestroyList()
 		if (m_keyboardFocus == doDestroy)
 			winSetFocus(NULL);
 
-		if ((m_modalHead != NULL) && (doDestroy == m_modalHead->window))
-			winUnsetModal(m_modalHead->window);
+		removeWindowFromModalStack(doDestroy);
 
-		if (m_currMouseRgn == doDestroy)
-			m_currMouseRgn = NULL;
+		if( m_currMouseRgn == doDestroy )
+			m_currMouseRgn = nullptr;
 
 		if (m_grabWindow == doDestroy)
 			m_grabWindow = NULL;
@@ -1423,8 +1422,7 @@ Int GameWindowManager::winDestroy(GameWindow* window)
 	if (m_keyboardFocus == window)
 		winSetFocus(NULL);
 
-	if ((m_modalHead != NULL) && (window == m_modalHead->window))
-		winUnsetModal(m_modalHead->window);
+	removeWindowFromModalStack( window );
 
 	if (m_currMouseRgn == window)
 		m_currMouseRgn = NULL;
@@ -1554,6 +1552,26 @@ Int GameWindowManager::winUnsetModal(GameWindow* window)
 
 	return WIN_ERR_OK;
 
+}
+
+// TheSuperHackers @bugfix arcticdolphin 27/08/2026 Remove destroyed windows from the entire modal stack.
+void GameWindowManager::removeWindowFromModalStack( GameWindow *window )
+{
+	ModalWindow **link = &m_modalHead;
+
+	while( *link )
+	{
+		ModalWindow *modal = *link;
+
+		if( modal->window != window )
+		{
+			link = &modal->next;
+			continue;
+		}
+
+		*link = modal->next;
+		deleteInstance(modal);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Removes every destroyed window from the modal stack before the window is released.

This prevents stale modal-stack pointers when a non-top modal window is destroyed, while preserving the rest of the GameClient modal-window behavior.